### PR TITLE
Pass arbitrary CMake options to llvm-builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.15"
+version = "1.0.16"
 dependencies = [
  "anyhow",
  "fs_extra",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "autocfg"
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.17"
+version = "1.0.16"
 dependencies = [
  "anyhow",
  "fs_extra",
@@ -46,9 +46,9 @@ dependencies = [
 
 [[package]]
 name = "fs_extra"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "hashbrown"
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -92,24 +92,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.146"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "f92be4933c13fd498862a9e02a3055f8a8d9c039ce33db97306fd5a6caa7f29b"
 
 [[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "nom8"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae01545c9c7fc4486ab7debaf2aad7003ac19431791868fb2e8066df97fad2f8"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "num_cpus"
@@ -136,7 +127,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
  "version_check",
 ]
 
@@ -153,47 +144,47 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "dec2b086b7a862cf4de201096214fa870344cf922b2b30c167badb3af3195406"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0efd8caf556a6cebd3b285caf480045fcc1ac04f6bd786b09a6f11af30c4fcf4"
+checksum = "93107647184f6027e3b7dcb2e11034cf95ffa1e3a682c67951963ac69c1c007d"
 dependencies = [
  "serde",
 ]
@@ -219,14 +210,25 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d41677bcbe24c20c52e7c70b0d8db04134c5d1066bf98662e2871ad200ea3e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -244,9 +246,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "772c1426ab886e7362aedf4abc9c0d1348a979517efedfc25862944d10137af0"
+checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -256,37 +258,37 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.19.1"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90a238ee2e6ede22fb95350acc78e21dc40da00bb66c0334bde83de4ed89424e"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
- "nom8",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"
@@ -299,3 +301,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "winnow"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
+dependencies = [
+ "memchr",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.16"
+version = "1.0.17"
 dependencies = [
  "anyhow",
  "fs_extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.17"
+version = "1.0.16"
 authors = [
     "Alex Zarudnyy <a.zarudnyy@matterlabs.dev>",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.15"
+version = "1.0.16"
 authors = [
     "Alex Zarudnyy <a.zarudnyy@matterlabs.dev>",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.16"
+version = "1.0.17"
 authors = [
     "Alex Zarudnyy <a.zarudnyy@matterlabs.dev>",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 [dependencies]
 structopt = { version = "0.3", default-features = false }
 anyhow = "1.0"
+snailquote = "0.3.1"
 
 serde = { version = "1.0", features = [ "derive" ] }
 toml = "0.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ doctest = false
 [dependencies]
 structopt = { version = "0.3", default-features = false }
 anyhow = "1.0"
-snailquote = "0.3.1"
 
 serde = { version = "1.0", features = [ "derive" ] }
 toml = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,24 +99,24 @@ pub fn checkout(lock: Lock, force: bool) -> anyhow::Result<()> {
 /// argument is not possible. So for cross-platform testing, comment out all but the
 /// line to be tested, and perhaps also checks in the platform-specific build method.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool) -> anyhow::Result<()> {
+pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
 
     if cfg!(target_arch = "x86_64") {
         if cfg!(target_os = "linux") {
             if cfg!(target_env = "gnu") {
-                platforms::x86_64_linux_gnu::build(build_type, enable_tests)?;
+                platforms::x86_64_linux_gnu::build(build_type, enable_tests, extra_args)?;
             } else if cfg!(target_env = "musl") {
-                platforms::x86_64_linux_musl::build(build_type, enable_tests)?;
+                platforms::x86_64_linux_musl::build(build_type, enable_tests, extra_args)?;
             }
         } else if cfg!(target_os = "macos") {
-            platforms::x86_64_macos::build(build_type, enable_tests)?;
+            platforms::x86_64_macos::build(build_type, enable_tests, extra_args)?;
         } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
-            platforms::x86_64_windows_gnu::build(build_type, enable_tests)?;
+            platforms::x86_64_windows_gnu::build(build_type, enable_tests, extra_args)?;
         }
     } else if cfg!(target_arch = "aarch64") {
         if cfg!(target_os = "macos") {
-            platforms::aarch64_macos::build(build_type, enable_tests)?;
+            platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
         }
     } else {
         anyhow::bail!("Unsupported on your machine");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,25 +102,25 @@ pub fn checkout(lock: Lock, force: bool) -> anyhow::Result<()> {
 pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
 
-    if cfg!(target_arch = "x86_64") {
-        if cfg!(target_os = "linux") {
-            if cfg!(target_env = "gnu") {
-                platforms::x86_64_linux_gnu::build(build_type, enable_tests, extra_args)?;
-            } else if cfg!(target_env = "musl") {
+    // if cfg!(target_arch = "x86_64") {
+    //     if cfg!(target_os = "linux") {
+    //         if cfg!(target_env = "gnu") {
+    //             platforms::x86_64_linux_gnu::build(build_type, enable_tests, extra_args)?;
+    //         } else if cfg!(target_env = "musl") {
                 platforms::x86_64_linux_musl::build(build_type, enable_tests, extra_args)?;
-            }
-        } else if cfg!(target_os = "macos") {
-            platforms::x86_64_macos::build(build_type, enable_tests, extra_args)?;
-        } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
-            platforms::x86_64_windows_gnu::build(build_type, enable_tests, extra_args)?;
-        }
-    } else if cfg!(target_arch = "aarch64") {
-        if cfg!(target_os = "macos") {
-            platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
-        }
-    } else {
-        anyhow::bail!("Unsupported on your machine");
-    }
+    //         }
+    //     } else if cfg!(target_os = "macos") {
+    //         platforms::x86_64_macos::build(build_type, enable_tests, extra_args)?;
+    //     } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
+    //         platforms::x86_64_windows_gnu::build(build_type, enable_tests, extra_args)?;
+    //     }
+    // } else if cfg!(target_arch = "aarch64") {
+    //     if cfg!(target_os = "macos") {
+    //         platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
+    //     }
+    // } else {
+    //     anyhow::bail!("Unsupported on your machine");
+    // }
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,6 +102,7 @@ pub fn checkout(lock: Lock, force: bool) -> anyhow::Result<()> {
 pub fn build(
     build_type: BuildType,
     enable_tests: bool,
+    enable_coverage: bool,
     extra_args: Vec<String>,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
@@ -109,18 +110,33 @@ pub fn build(
     if cfg!(target_arch = "x86_64") {
         if cfg!(target_os = "linux") {
             if cfg!(target_env = "gnu") {
-                platforms::x86_64_linux_gnu::build(build_type, enable_tests, extra_args)?;
+                platforms::x86_64_linux_gnu::build(
+                    build_type,
+                    enable_tests,
+                    enable_coverage,
+                    extra_args,
+                )?;
             } else if cfg!(target_env = "musl") {
-                platforms::x86_64_linux_musl::build(build_type, enable_tests, extra_args)?;
+                platforms::x86_64_linux_musl::build(
+                    build_type,
+                    enable_tests,
+                    enable_coverage,
+                    extra_args,
+                )?;
             }
         } else if cfg!(target_os = "macos") {
-            platforms::x86_64_macos::build(build_type, enable_tests, extra_args)?;
+            platforms::x86_64_macos::build(build_type, enable_tests, enable_coverage, extra_args)?;
         } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
-            platforms::x86_64_windows_gnu::build(build_type, enable_tests, extra_args)?;
+            platforms::x86_64_windows_gnu::build(
+                build_type,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+            )?;
         }
     } else if cfg!(target_arch = "aarch64") {
         if cfg!(target_os = "macos") {
-            platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
+            platforms::aarch64_macos::build(build_type, enable_tests, enable_coverage, extra_args)?;
         }
     } else {
         anyhow::bail!("Unsupported on your machine");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub fn build(
             if cfg!(target_env = "gnu") {
                 platforms::x86_64_linux_gnu::build(build_type, enable_tests, extra_args)?;
             } else if cfg!(target_env = "musl") {
-    platforms::x86_64_linux_musl::build(build_type, enable_tests, extra_args)?;
+                platforms::x86_64_linux_musl::build(build_type, enable_tests, extra_args)?;
             }
         } else if cfg!(target_os = "macos") {
             platforms::x86_64_macos::build(build_type, enable_tests, extra_args)?;
@@ -120,7 +120,7 @@ pub fn build(
         }
     } else if cfg!(target_arch = "aarch64") {
         if cfg!(target_os = "macos") {
-    platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
+            platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
         }
     } else {
         anyhow::bail!("Unsupported on your machine");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,28 +99,32 @@ pub fn checkout(lock: Lock, force: bool) -> anyhow::Result<()> {
 /// argument is not possible. So for cross-platform testing, comment out all but the
 /// line to be tested, and perhaps also checks in the platform-specific build method.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
+pub fn build(
+    build_type: BuildType,
+    enable_tests: bool,
+    extra_args: Vec<String>,
+) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
 
-    // if cfg!(target_arch = "x86_64") {
-    //     if cfg!(target_os = "linux") {
-    //         if cfg!(target_env = "gnu") {
-    //             platforms::x86_64_linux_gnu::build(build_type, enable_tests, extra_args)?;
-    //         } else if cfg!(target_env = "musl") {
-                platforms::x86_64_linux_musl::build(build_type, enable_tests, extra_args)?;
-    //         }
-    //     } else if cfg!(target_os = "macos") {
-    //         platforms::x86_64_macos::build(build_type, enable_tests, extra_args)?;
-    //     } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
-    //         platforms::x86_64_windows_gnu::build(build_type, enable_tests, extra_args)?;
-    //     }
-    // } else if cfg!(target_arch = "aarch64") {
-    //     if cfg!(target_os = "macos") {
-    //         platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
-    //     }
-    // } else {
-    //     anyhow::bail!("Unsupported on your machine");
-    // }
+    if cfg!(target_arch = "x86_64") {
+        if cfg!(target_os = "linux") {
+            if cfg!(target_env = "gnu") {
+                platforms::x86_64_linux_gnu::build(build_type, enable_tests, extra_args)?;
+            } else if cfg!(target_env = "musl") {
+    platforms::x86_64_linux_musl::build(build_type, enable_tests, extra_args)?;
+            }
+        } else if cfg!(target_os = "macos") {
+            platforms::x86_64_macos::build(build_type, enable_tests, extra_args)?;
+        } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
+            platforms::x86_64_windows_gnu::build(build_type, enable_tests, extra_args)?;
+        }
+    } else if cfg!(target_arch = "aarch64") {
+        if cfg!(target_os = "macos") {
+    platforms::aarch64_macos::build(build_type, enable_tests, extra_args)?;
+        }
+    } else {
+        anyhow::bail!("Unsupported on your machine");
+    }
 
     Ok(())
 }

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -13,6 +13,7 @@ use crate::llvm_path::LLVMPath;
 pub fn build(
     build_type: BuildType,
     enable_tests: bool,
+    enable_coverage: bool,
     extra_args: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
@@ -38,27 +39,11 @@ pub fn build(
                 .as_str(),
                 format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
-                format!(
-                    "-DLLVM_BUILD_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_BUILD_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
             ])
+            .args(crate::platforms::shared_build_opts_tests(enable_tests))
+            .args(crate::platforms::shared_build_opts_coverage(
+                enable_coverage,
+            ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args),

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -10,7 +10,7 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool) -> anyhow::Result<()> {
+pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
 

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -56,7 +56,8 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
             .as_str(),
         ])
         .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL),
+        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+        .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -10,7 +10,11 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
+pub fn build(
+    build_type: BuildType,
+    enable_tests: bool,
+    extra_args: Vec<String>,
+) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
 
@@ -19,45 +23,45 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
     let llvm_target_final = LLVMPath::llvm_target_final()?;
 
     crate::utils::command(
-        Command::new("cmake").args([
-            "-S",
-            llvm_module_llvm.to_string_lossy().as_ref(),
-            "-B",
-            llvm_build_final.to_string_lossy().as_ref(),
-            "-G",
-            "Ninja",
-            format!(
-                "-DCMAKE_INSTALL_PREFIX='{}'",
-                llvm_target_final.to_string_lossy().as_ref(),
-            )
-            .as_str(),
-            format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
-            "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
-
-            format!(
-                "-DLLVM_BUILD_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_BUILD_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-        ])
-        .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-        .args(extra_args),
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
+                format!(
+                    "-DLLVM_BUILD_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_BUILD_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+            ])
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -40,3 +40,33 @@ pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 7] = [
     "-DLLVM_INCLUDE_RUNTIMES='Off'",
     "-DLLVM_ENABLE_ASSERTIONS='On'",
 ];
+
+/// The LLVM tests build options shared by all platforms.
+pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {
+    vec![
+        format!(
+            "-DLLVM_BUILD_UTILS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+        format!(
+            "-DLLVM_BUILD_TESTS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+        format!(
+            "-DLLVM_INCLUDE_UTILS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+        format!(
+            "-DLLVM_INCLUDE_TESTS='{}'",
+            if enabled { "On" } else { "Off" },
+        ),
+    ]
+}
+
+/// The code coverage build options shared by all platforms.
+pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
+    vec![format!(
+        "-DLLVM_BUILD_INSTRUMENTED_COVERAGE='{}'",
+        if enabled { "On" } else { "Off" },
+    )]
+}

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -8,7 +8,7 @@ pub mod x86_64_linux_musl;
 pub mod x86_64_macos;
 pub mod x86_64_windows_gnu;
 
-pub const SHARED_BUILD_OPTS: [&'static str; 18] = [
+pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCLANG_VENDOR='Matter Labs'",
     "-DCLANG_REPOSITORY_STRING='origin'",
@@ -30,7 +30,7 @@ pub const SHARED_BUILD_OPTS: [&'static str; 18] = [
 
     ];
 
-pub const SHARED_BUILD_OPTS_NOT_MUSL: [&'static str; 7] = [
+pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 7] = [
     "-DLLVM_TARGETS_TO_BUILD=\'SyncVM\'",
     "-DLLVM_DEFAULT_TARGET_TRIPLE='syncvm'",
     "-DLLVM_OPTIMIZED_TABLEGEN='On'",

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -8,6 +8,7 @@ pub mod x86_64_linux_musl;
 pub mod x86_64_macos;
 pub mod x86_64_windows_gnu;
 
+/// The build options shared by all platforms.
 pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCLANG_VENDOR='Matter Labs'",
@@ -30,6 +31,7 @@ pub const SHARED_BUILD_OPTS: [&str; 18] = [
 
     ];
 
+/// The build options shared by all platforms except MUSL.
 pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 7] = [
     "-DLLVM_TARGETS_TO_BUILD=\'SyncVM\'",
     "-DLLVM_DEFAULT_TARGET_TRIPLE='syncvm'",

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -28,8 +28,7 @@ pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DLLVM_ENABLE_TERMINFO='Off'",
     "-DLLVM_ENABLE_LIBEDIT='Off'",
     "-DLLVM_ENABLE_LIBPFM='Off'",
-
-    ];
+];
 
 /// The build options shared by all platforms except MUSL.
 pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 7] = [
@@ -40,4 +39,4 @@ pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 7] = [
     "-DLLVM_BUILD_RUNTIMES='Off'",
     "-DLLVM_INCLUDE_RUNTIMES='Off'",
     "-DLLVM_ENABLE_ASSERTIONS='On'",
-    ];
+];

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -10,7 +10,7 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool) -> anyhow::Result<()> {
+pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -10,7 +10,11 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
+pub fn build(
+    build_type: BuildType,
+    enable_tests: bool,
+    extra_args: Vec<String>,
+) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;
@@ -22,47 +26,47 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
     let llvm_target_final = LLVMPath::llvm_target_final()?;
 
     crate::utils::command(
-        Command::new("cmake").args([
-            "-S",
-            llvm_module_llvm.to_string_lossy().as_ref(),
-            "-B",
-            llvm_build_final.to_string_lossy().as_ref(),
-            "-G",
-            "Ninja",
-            format!(
-                "-DCMAKE_INSTALL_PREFIX='{}'",
-                llvm_target_final.to_string_lossy().as_ref(),
-            )
-            .as_str(),
-            format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
-            "-DCMAKE_C_COMPILER='clang'",
-            "-DCMAKE_CXX_COMPILER='clang++'",
-
-            "-DLLVM_USE_LINKER='lld'",
-            format!(
-                "-DLLVM_BUILD_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_BUILD_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-        ])
-        .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-        .args(extra_args),
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                "-DCMAKE_C_COMPILER='clang'",
+                "-DCMAKE_CXX_COMPILER='clang++'",
+                "-DLLVM_USE_LINKER='lld'",
+                format!(
+                    "-DLLVM_BUILD_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_BUILD_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+            ])
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -61,7 +61,8 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
             .as_str(),
         ])
         .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL),
+        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+        .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -13,6 +13,7 @@ use crate::llvm_path::LLVMPath;
 pub fn build(
     build_type: BuildType,
     enable_tests: bool,
+    enable_coverage: bool,
     extra_args: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
@@ -43,27 +44,11 @@ pub fn build(
                 "-DCMAKE_C_COMPILER='clang'",
                 "-DCMAKE_CXX_COMPILER='clang++'",
                 "-DLLVM_USE_LINKER='lld'",
-                format!(
-                    "-DLLVM_BUILD_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_BUILD_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
             ])
+            .args(crate::platforms::shared_build_opts_tests(enable_tests))
+            .args(crate::platforms::shared_build_opts_coverage(
+                enable_coverage,
+            ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args),

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -141,7 +141,7 @@ fn build_musl(build_directory: &Path, target_directory: &Path) -> anyhow::Result
         copy_inside: true,
         ..Default::default()
     };
-    // fs_extra::dir::copy("/usr/include/linux", include_directory, &copy_options)?;
+    fs_extra::dir::copy("/usr/include/linux", include_directory, &copy_options)?;
 
     let copy_options = fs_extra::dir::CopyOptions {
         overwrite: true,
@@ -149,11 +149,11 @@ fn build_musl(build_directory: &Path, target_directory: &Path) -> anyhow::Result
         content_only: true,
         ..Default::default()
     };
-    // fs_extra::dir::copy(
-    //     "/usr/include/asm-generic",
-    //     asm_include_directory,
-    //     &copy_options,
-    // )?;
+    fs_extra::dir::copy(
+        "/usr/include/asm-generic",
+        asm_include_directory,
+        &copy_options,
+    )?;
 
     crate::utils::command(
         Command::new("sed")

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -11,7 +11,11 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
+pub fn build(
+    build_type: BuildType,
+    enable_tests: bool,
+    extra_args: Vec<String>,
+) -> anyhow::Result<()> {
     crate::utils::check_presence("wget")?;
     crate::utils::check_presence("tar")?;
     crate::utils::check_presence("cmake")?;
@@ -175,41 +179,42 @@ fn build_crt(
     target_directory: &Path,
 ) -> anyhow::Result<()> {
     crate::utils::command(
-        Command::new("cmake").args([
-            "-S",
-            source_directory.to_string_lossy().as_ref(),
-            "-B",
-            build_directory.to_string_lossy().as_ref(),
-            "-G",
-            "Ninja",
-            format!(
-                "-DCMAKE_INSTALL_PREFIX='{}'",
-                target_directory.to_string_lossy()
-            )
-            .as_str(),
-            "-DCMAKE_BUILD_TYPE='Release'",
-            "-DCMAKE_C_COMPILER='clang'",
-            "-DCMAKE_CXX_COMPILER='clang++'",
-            "-DLLVM_ENABLE_PROJECTS='compiler-rt'",
-            "-DLLVM_TARGETS_TO_BUILD='X86;SyncVM'",
-            "-DLLVM_DEFAULT_TARGET_TRIPLE='x86_64-pc-linux-musl'",
-            "-DLLVM_BUILD_TESTS='Off'",
-            "-DLLVM_BUILD_RUNTIMES='Off'",
-            "-DLLVM_BUILD_UTILS='Off'",
-            "-DLLVM_INCLUDE_TESTS='Off'",
-            "-DLLVM_INCLUDE_RUNTIMES='Off'",
-            "-DLLVM_INCLUDE_UTILS='Off'",
-            "-DLLVM_ENABLE_ASSERTIONS='Off'",
-            "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='x86_64'",
-            "-DCOMPILER_RT_BUILD_CRT='On'",
-            "-DCOMPILER_RT_BUILD_SANITIZERS='Off'",
-            "-DCOMPILER_RT_BUILD_XRAY='Off'",
-            "-DCOMPILER_RT_BUILD_LIBFUZZER='Off'",
-            "-DCOMPILER_RT_BUILD_PROFILE='Off'",
-            "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
-            "-DCOMPILER_RT_BUILD_ORC='Off'",
-        ])
-        .args(crate::platforms::SHARED_BUILD_OPTS),
+        Command::new("cmake")
+            .args([
+                "-S",
+                source_directory.to_string_lossy().as_ref(),
+                "-B",
+                build_directory.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    target_directory.to_string_lossy()
+                )
+                .as_str(),
+                "-DCMAKE_BUILD_TYPE='Release'",
+                "-DCMAKE_C_COMPILER='clang'",
+                "-DCMAKE_CXX_COMPILER='clang++'",
+                "-DLLVM_ENABLE_PROJECTS='compiler-rt'",
+                "-DLLVM_TARGETS_TO_BUILD='X86;SyncVM'",
+                "-DLLVM_DEFAULT_TARGET_TRIPLE='x86_64-pc-linux-musl'",
+                "-DLLVM_BUILD_TESTS='Off'",
+                "-DLLVM_BUILD_RUNTIMES='Off'",
+                "-DLLVM_BUILD_UTILS='Off'",
+                "-DLLVM_INCLUDE_TESTS='Off'",
+                "-DLLVM_INCLUDE_RUNTIMES='Off'",
+                "-DLLVM_INCLUDE_UTILS='Off'",
+                "-DLLVM_ENABLE_ASSERTIONS='Off'",
+                "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='x86_64'",
+                "-DCOMPILER_RT_BUILD_CRT='On'",
+                "-DCOMPILER_RT_BUILD_SANITIZERS='Off'",
+                "-DCOMPILER_RT_BUILD_XRAY='Off'",
+                "-DCOMPILER_RT_BUILD_LIBFUZZER='Off'",
+                "-DCOMPILER_RT_BUILD_PROFILE='Off'",
+                "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
+                "-DCOMPILER_RT_BUILD_ORC='Off'",
+            ])
+            .args(crate::platforms::SHARED_BUILD_OPTS),
         "CRT building cmake",
     )?;
 
@@ -235,61 +240,62 @@ fn build_host(
     crt_target_directory: &Path,
 ) -> anyhow::Result<()> {
     crate::utils::command(
-        Command::new("cmake").args([
-            "-S",
-            source_directory.to_string_lossy().as_ref(),
-            "-B",
-            build_directory.to_string_lossy().as_ref(),
-            "-G",
-            "Ninja",
-            format!(
-                "-DDEFAULT_SYSROOT='{}'",
-                musl_target_directory.to_string_lossy()
-            )
-            .as_str(),
-            "-DLINKER_SUPPORTS_COLOR_DIAGNOSTICS=0",
-            format!(
-                "-DCMAKE_INSTALL_PREFIX='{}'",
-                target_directory.to_string_lossy()
-            )
-            .as_str(),
-            "-DCMAKE_BUILD_TYPE='Release'",
-            "-DCMAKE_C_COMPILER='clang'",
-            "-DCMAKE_CXX_COMPILER='clang++'",
-            "-DCLANG_DEFAULT_CXX_STDLIB='libc++'",
-            "-DCLANG_DEFAULT_RTLIB='compiler-rt'",
-            "-DLLVM_DEFAULT_TARGET_TRIPLE='x86_64-pc-linux-musl'",
-            "-DLLVM_TARGETS_TO_BUILD='X86'",
-            "-DLLVM_BUILD_TESTS='Off'",
-            "-DLLVM_BUILD_UTILS='Off'",
-            "-DLLVM_INCLUDE_TESTS='Off'",
-            "-DLLVM_INCLUDE_UTILS='Off'",
-            "-DLLVM_ENABLE_ASSERTIONS='Off'",
-            "-DLLVM_ENABLE_PROJECTS='clang;lld'",
-            "-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind'",
-            "-DLIBCXX_CXX_ABI='libcxxabi'",
-            "-DLIBCXX_HAS_MUSL_LIBC='On'",
-            "-DLIBCXX_ENABLE_SHARED='Off'",
-            "-DLIBCXX_ENABLE_STATIC='On'",
-            "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY='On'",
-            "-DLIBCXXABI_ENABLE_SHARED='Off'",
-            "-DLIBCXXABI_ENABLE_STATIC='On'",
-            "-DLIBCXXABI_ENABLE_STATIC_UNWINDER='On'",
-            "-DLIBCXXABI_USE_LLVM_UNWINDER='On'",
-            "-DLIBCXXABI_USE_COMPILER_RT='On'",
-            "-DLIBUNWIND_ENABLE_STATIC='On'",
-            "-DLIBUNWIND_ENABLE_SHARED='Off'",
-            "-DCOMPILER_RT_BUILD_CRT='On'",
-            "-DCOMPILER_RT_BUILD_SANITIZERS='Off'",
-            "-DCOMPILER_RT_BUILD_XRAY='Off'",
-            "-DCOMPILER_RT_BUILD_LIBFUZZER='Off'",
-            "-DCOMPILER_RT_BUILD_PROFILE='Off'",
-            "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
-            "-DCOMPILER_RT_BUILD_ORC='Off'",
-            "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='x86_64'",
-            "-DCOMPILER_RT_DEFAULT_TARGET_ONLY='On'",
-        ])
-        .args(crate::platforms::SHARED_BUILD_OPTS),
+        Command::new("cmake")
+            .args([
+                "-S",
+                source_directory.to_string_lossy().as_ref(),
+                "-B",
+                build_directory.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DDEFAULT_SYSROOT='{}'",
+                    musl_target_directory.to_string_lossy()
+                )
+                .as_str(),
+                "-DLINKER_SUPPORTS_COLOR_DIAGNOSTICS=0",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    target_directory.to_string_lossy()
+                )
+                .as_str(),
+                "-DCMAKE_BUILD_TYPE='Release'",
+                "-DCMAKE_C_COMPILER='clang'",
+                "-DCMAKE_CXX_COMPILER='clang++'",
+                "-DCLANG_DEFAULT_CXX_STDLIB='libc++'",
+                "-DCLANG_DEFAULT_RTLIB='compiler-rt'",
+                "-DLLVM_DEFAULT_TARGET_TRIPLE='x86_64-pc-linux-musl'",
+                "-DLLVM_TARGETS_TO_BUILD='X86'",
+                "-DLLVM_BUILD_TESTS='Off'",
+                "-DLLVM_BUILD_UTILS='Off'",
+                "-DLLVM_INCLUDE_TESTS='Off'",
+                "-DLLVM_INCLUDE_UTILS='Off'",
+                "-DLLVM_ENABLE_ASSERTIONS='Off'",
+                "-DLLVM_ENABLE_PROJECTS='clang;lld'",
+                "-DLLVM_ENABLE_RUNTIMES='compiler-rt;libcxx;libcxxabi;libunwind'",
+                "-DLIBCXX_CXX_ABI='libcxxabi'",
+                "-DLIBCXX_HAS_MUSL_LIBC='On'",
+                "-DLIBCXX_ENABLE_SHARED='Off'",
+                "-DLIBCXX_ENABLE_STATIC='On'",
+                "-DLIBCXX_ENABLE_STATIC_ABI_LIBRARY='On'",
+                "-DLIBCXXABI_ENABLE_SHARED='Off'",
+                "-DLIBCXXABI_ENABLE_STATIC='On'",
+                "-DLIBCXXABI_ENABLE_STATIC_UNWINDER='On'",
+                "-DLIBCXXABI_USE_LLVM_UNWINDER='On'",
+                "-DLIBCXXABI_USE_COMPILER_RT='On'",
+                "-DLIBUNWIND_ENABLE_STATIC='On'",
+                "-DLIBUNWIND_ENABLE_SHARED='Off'",
+                "-DCOMPILER_RT_BUILD_CRT='On'",
+                "-DCOMPILER_RT_BUILD_SANITIZERS='Off'",
+                "-DCOMPILER_RT_BUILD_XRAY='Off'",
+                "-DCOMPILER_RT_BUILD_LIBFUZZER='Off'",
+                "-DCOMPILER_RT_BUILD_PROFILE='Off'",
+                "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
+                "-DCOMPILER_RT_BUILD_ORC='Off'",
+                "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='x86_64'",
+                "-DCOMPILER_RT_DEFAULT_TARGET_ONLY='On'",
+            ])
+            .args(crate::platforms::SHARED_BUILD_OPTS),
         "LLVM host building cmake",
     )?;
 
@@ -330,7 +336,7 @@ fn build_target(
     musl_target_directory: &Path,
     host_target_directory: &Path,
     enable_tests: bool,
-    extra_args: Vec<String>
+    extra_args: Vec<String>,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -339,60 +345,61 @@ fn build_target(
     clang_cxx_path.push("bin/clang++");
 
     crate::utils::command(
-        Command::new("cmake").args([
-            "-S",
-            source_directory.to_string_lossy().as_ref(),
-            "-B",
-            build_directory.to_string_lossy().as_ref(),
-            "-G",
-            "Ninja",
-            "-DBUILD_SHARED_LIBS='Off'",
-            "-DLINKER_SUPPORTS_COLOR_DIAGNOSTICS=0",
-            format!(
-                "-DCMAKE_INSTALL_PREFIX='{}'",
-                target_directory.to_string_lossy()
-            )
-            .as_str(),
-            format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
-            format!("-DCMAKE_C_COMPILER='{}'", clang_path.to_string_lossy()).as_str(),
-            format!(
-                "-DCMAKE_CXX_COMPILER='{}'",
-                clang_cxx_path.to_string_lossy()
-            )
-            .as_str(),
-            "-DCMAKE_FIND_LIBRARY_SUFFIXES='.a'",
-            "-DCMAKE_EXE_LINKER_FLAGS='-fuse-ld=lld -static'",
-            "-DLLVM_TARGETS_TO_BUILD='SyncVM'",
-            "-DLLVM_DEFAULT_TARGET_TRIPLE='syncvm'",
-            "-DLLVM_OPTIMIZED_TABLEGEN='On'",
-            format!(
-                "-DLLVM_BUILD_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_BUILD_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            "-DLLVM_BUILD_RUNTIME='Off'",
-            "-DLLVM_BUILD_RUNTIMES='Off'",
-            format!(
-                "-DLLVM_INCLUDE_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            "-DLLVM_INCLUDE_RUNTIMES='Off'",
-            "-DLLVM_ENABLE_PROJECTS='llvm'",
-            "-DLLVM_ENABLE_ASSERTIONS='On'",
-        ])
-        .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(extra_args),
+        Command::new("cmake")
+            .args([
+                "-S",
+                source_directory.to_string_lossy().as_ref(),
+                "-B",
+                build_directory.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                "-DBUILD_SHARED_LIBS='Off'",
+                "-DLINKER_SUPPORTS_COLOR_DIAGNOSTICS=0",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    target_directory.to_string_lossy()
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                format!("-DCMAKE_C_COMPILER='{}'", clang_path.to_string_lossy()).as_str(),
+                format!(
+                    "-DCMAKE_CXX_COMPILER='{}'",
+                    clang_cxx_path.to_string_lossy()
+                )
+                .as_str(),
+                "-DCMAKE_FIND_LIBRARY_SUFFIXES='.a'",
+                "-DCMAKE_EXE_LINKER_FLAGS='-fuse-ld=lld -static'",
+                "-DLLVM_TARGETS_TO_BUILD='SyncVM'",
+                "-DLLVM_DEFAULT_TARGET_TRIPLE='syncvm'",
+                "-DLLVM_OPTIMIZED_TABLEGEN='On'",
+                format!(
+                    "-DLLVM_BUILD_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_BUILD_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                "-DLLVM_BUILD_RUNTIME='Off'",
+                "-DLLVM_BUILD_RUNTIMES='Off'",
+                format!(
+                    "-DLLVM_INCLUDE_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                "-DLLVM_INCLUDE_RUNTIMES='Off'",
+                "-DLLVM_ENABLE_PROJECTS='llvm'",
+                "-DLLVM_ENABLE_ASSERTIONS='On'",
+            ])
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(extra_args),
         "LLVM target building cmake",
     )?;
 

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -17,7 +17,7 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;
-    // crate::utils::check_presence("lld")?;
+    crate::utils::check_presence("lld")?;
     crate::utils::check_presence("ninja")?;
 
     let musl_name = "musl-1.2.3";

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -11,7 +11,7 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool) -> anyhow::Result<()> {
+pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
     crate::utils::check_presence("wget")?;
     crate::utils::check_presence("tar")?;
     crate::utils::check_presence("cmake")?;

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -17,7 +17,7 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;
-    crate::utils::check_presence("lld")?;
+    // crate::utils::check_presence("lld")?;
     crate::utils::check_presence("ninja")?;
 
     let musl_name = "musl-1.2.3";
@@ -141,7 +141,7 @@ fn build_musl(build_directory: &Path, target_directory: &Path) -> anyhow::Result
         copy_inside: true,
         ..Default::default()
     };
-    fs_extra::dir::copy("/usr/include/linux", include_directory, &copy_options)?;
+    // fs_extra::dir::copy("/usr/include/linux", include_directory, &copy_options)?;
 
     let copy_options = fs_extra::dir::CopyOptions {
         overwrite: true,
@@ -149,11 +149,11 @@ fn build_musl(build_directory: &Path, target_directory: &Path) -> anyhow::Result
         content_only: true,
         ..Default::default()
     };
-    fs_extra::dir::copy(
-        "/usr/include/asm-generic",
-        asm_include_directory,
-        &copy_options,
-    )?;
+    // fs_extra::dir::copy(
+    //     "/usr/include/asm-generic",
+    //     asm_include_directory,
+    //     &copy_options,
+    // )?;
 
     crate::utils::command(
         Command::new("sed")

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -57,6 +57,7 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
         musl_target.as_path(),
         llvm_target_host.as_path(),
         enable_tests,
+        extra_args,
     )?;
 
     Ok(())
@@ -320,6 +321,7 @@ fn build_host(
 ///
 /// The target toolchain building sequence.
 ///
+#[allow(clippy::too_many_arguments)]
 fn build_target(
     build_type: BuildType,
     source_directory: &Path,
@@ -328,6 +330,7 @@ fn build_target(
     musl_target_directory: &Path,
     host_target_directory: &Path,
     enable_tests: bool,
+    extra_args: Vec<String>
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -388,7 +391,8 @@ fn build_target(
             "-DLLVM_ENABLE_PROJECTS='llvm'",
             "-DLLVM_ENABLE_ASSERTIONS='On'",
         ])
-        .args(crate::platforms::SHARED_BUILD_OPTS),
+        .args(crate::platforms::SHARED_BUILD_OPTS)
+        .args(extra_args),
         "LLVM target building cmake",
     )?;
 

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -13,6 +13,7 @@ use crate::llvm_path::LLVMPath;
 pub fn build(
     build_type: BuildType,
     enable_tests: bool,
+    enable_coverage: bool,
     extra_args: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
@@ -38,27 +39,11 @@ pub fn build(
                 .as_str(),
                 format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
                 "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
-                format!(
-                    "-DLLVM_BUILD_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_BUILD_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
             ])
+            .args(crate::platforms::shared_build_opts_tests(enable_tests))
+            .args(crate::platforms::shared_build_opts_coverage(
+                enable_coverage,
+            ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args),

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -10,7 +10,7 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool) -> anyhow::Result<()> {
+pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
 

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -56,7 +56,8 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
             .as_str(),
         ])
         .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL),
+        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+        .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -10,7 +10,11 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
+pub fn build(
+    build_type: BuildType,
+    enable_tests: bool,
+    extra_args: Vec<String>,
+) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
 
@@ -19,45 +23,45 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
     let llvm_target_final = LLVMPath::llvm_target_final()?;
 
     crate::utils::command(
-        Command::new("cmake").args([
-            "-S",
-            llvm_module_llvm.to_string_lossy().as_ref(),
-            "-B",
-            llvm_build_final.to_string_lossy().as_ref(),
-            "-G",
-            "Ninja",
-            format!(
-                "-DCMAKE_INSTALL_PREFIX='{}'",
-                llvm_target_final.to_string_lossy().as_ref(),
-            )
-            .as_str(),
-            format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
-            "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
-
-            format!(
-                "-DLLVM_BUILD_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_BUILD_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-        ])
-        .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-        .args(extra_args),
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                "-DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'",
+                format!(
+                    "-DLLVM_BUILD_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_BUILD_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+            ])
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -11,7 +11,7 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool) -> anyhow::Result<()> {
+pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -11,7 +11,11 @@ use crate::llvm_path::LLVMPath;
 ///
 /// The building sequence.
 ///
-pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>) -> anyhow::Result<()> {
+pub fn build(
+    build_type: BuildType,
+    enable_tests: bool,
+    extra_args: Vec<String>,
+) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;
@@ -26,47 +30,47 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
         LLVMPath::llvm_target_final().and_then(crate::utils::path_windows_to_unix)?;
 
     crate::utils::command(
-        Command::new("cmake").args([
-            "-S",
-            llvm_module_llvm.to_string_lossy().as_ref(),
-            "-B",
-            llvm_build_final.to_string_lossy().as_ref(),
-            "-G",
-            "Ninja",
-            format!(
-                "-DCMAKE_INSTALL_PREFIX='{}'",
-                llvm_target_final.to_string_lossy().as_ref(),
-            )
-            .as_str(),
-            format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
-            "-DCMAKE_C_COMPILER='clang'",
-            "-DCMAKE_CXX_COMPILER='clang++'",
-
-            "-DLLVM_USE_LINKER='lld'",
-            format!(
-                "-DLLVM_BUILD_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_BUILD_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_UTILS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-            format!(
-                "-DLLVM_INCLUDE_TESTS='{}'",
-                if enable_tests { "On" } else { "Off" },
-            )
-            .as_str(),
-        ])
-        .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-        .args(extra_args),
+        Command::new("cmake")
+            .args([
+                "-S",
+                llvm_module_llvm.to_string_lossy().as_ref(),
+                "-B",
+                llvm_build_final.to_string_lossy().as_ref(),
+                "-G",
+                "Ninja",
+                format!(
+                    "-DCMAKE_INSTALL_PREFIX='{}'",
+                    llvm_target_final.to_string_lossy().as_ref(),
+                )
+                .as_str(),
+                format!("-DCMAKE_BUILD_TYPE='{build_type}'").as_str(),
+                "-DCMAKE_C_COMPILER='clang'",
+                "-DCMAKE_CXX_COMPILER='clang++'",
+                "-DLLVM_USE_LINKER='lld'",
+                format!(
+                    "-DLLVM_BUILD_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_BUILD_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_UTILS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+                format!(
+                    "-DLLVM_INCLUDE_TESTS='{}'",
+                    if enable_tests { "On" } else { "Off" },
+                )
+                .as_str(),
+            ])
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -14,6 +14,7 @@ use crate::llvm_path::LLVMPath;
 pub fn build(
     build_type: BuildType,
     enable_tests: bool,
+    enable_coverage: bool,
     extra_args: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
@@ -47,27 +48,11 @@ pub fn build(
                 "-DCMAKE_C_COMPILER='clang'",
                 "-DCMAKE_CXX_COMPILER='clang++'",
                 "-DLLVM_USE_LINKER='lld'",
-                format!(
-                    "-DLLVM_BUILD_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_BUILD_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_UTILS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
-                format!(
-                    "-DLLVM_INCLUDE_TESTS='{}'",
-                    if enable_tests { "On" } else { "Off" },
-                )
-                .as_str(),
             ])
+            .args(crate::platforms::shared_build_opts_tests(enable_tests))
+            .args(crate::platforms::shared_build_opts_coverage(
+                enable_coverage,
+            ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args),

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -65,7 +65,8 @@ pub fn build(build_type: BuildType, enable_tests: bool, extra_args: Vec<String>)
             .as_str(),
         ])
         .args(crate::platforms::SHARED_BUILD_OPTS)
-        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL),
+        .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
+        .args(extra_args),
         "LLVM building cmake",
     )?;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 
 use path_slash::PathBufExt;
 
-const DRY_RUN: bool = true;
+const DRY_RUN: bool = false;
 const VERBOSE: bool = true;
 
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,7 @@ use std::process::Command;
 use path_slash::PathBufExt;
 
 const DRY_RUN: bool = false;
+/// Enable verbose output.
 pub const VERBOSE: bool = true;
 
 ///

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -19,8 +19,10 @@ const VERBOSE: bool = true;
 pub fn command(command: &mut Command, description: &str) -> anyhow::Result<()> {
     if VERBOSE {
         println!("description: {}; command: {:?}", description, command);
-    }    
-    if !DRY_RUN {
+    }
+    if DRY_RUN {
+        println!("Only a dry run; not executing the command.");
+    } else {
         let status = command
             .status()
             .map_err(|error| anyhow::anyhow!("{} process: {}", description, error))?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -18,10 +18,10 @@ const VERBOSE: bool = true;
 ///
 pub fn command(command: &mut Command, description: &str) -> anyhow::Result<()> {
     if VERBOSE {
-        println!("description: {}; command: {:?}", description, command);
+        println!("\ndescription: {}; command: {:?}", description, command);
     }
     if DRY_RUN {
-        println!("Only a dry run; not executing the command.");
+        println!("\tOnly a dry run; not executing the command.");
     } else {
         let status = command
             .status()

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ use path_slash::PathBufExt;
 
 const DRY_RUN: bool = false;
 /// Enable verbose output.
-pub const VERBOSE: bool = true;
+pub const VERBOSE: bool = false;
 
 ///
 /// The subprocess runner.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 use path_slash::PathBufExt;
 
 const DRY_RUN: bool = false;
-const VERBOSE: bool = true;
+pub const VERBOSE: bool = true;
 
 ///
 /// The subprocess runner.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,7 +10,7 @@ use path_slash::PathBufExt;
 
 const DRY_RUN: bool = false;
 /// Enable verbose output.
-pub const VERBOSE: bool = false;
+pub const VERBOSE: bool = true;
 
 ///
 /// The subprocess runner.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,8 +8,8 @@ use std::process::Command;
 
 use path_slash::PathBufExt;
 
-const DRY_RUN: bool = false;
-const VERBOSE: bool = false;
+const DRY_RUN: bool = true;
+const VERBOSE: bool = true;
 
 ///
 /// The subprocess runner.

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -20,6 +20,9 @@ pub enum Arguments {
         /// Whether to build the LLVM tests.
         #[structopt(long = "enable-tests")]
         enable_tests: bool,
+        /// Extra arguments to pass to the LLVM build system.
+        #[structopt(long = "extra-args", multiple = true, help = "Extra arguments to pass to the LLVM build system")]
+        extra_args: Vec<String>,
     },
     /// Checkout the branch specified in `LLVM.lock`.
     Checkout {

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -20,8 +20,9 @@ pub enum Arguments {
         /// Whether to build the LLVM tests.
         #[structopt(long = "enable-tests")]
         enable_tests: bool,
-        /// Extra arguments to pass to the LLVM build system.
-        #[structopt(long = "extra-args", multiple = true, help = "Extra arguments to pass to the LLVM build system")]
+        /// Extra arguments to pass to CMake.  
+        /// A leading backslash will be unescaped.
+        #[structopt(long = "extra-args", multiple = true)]
         extra_args: Vec<String>,
     },
     /// Checkout the branch specified in `LLVM.lock`.

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -20,6 +20,9 @@ pub enum Arguments {
         /// Whether to build the LLVM tests.
         #[structopt(long = "enable-tests")]
         enable_tests: bool,
+        /// Whether to build LLVM for source-based code coverage.
+        #[structopt(long = "enable-coverage")]
+        enable_coverage: bool,
         /// Extra arguments to pass to CMake.  
         /// A leading backslash will be unescaped.
         #[structopt(long = "extra-args", multiple = true)]

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -4,9 +4,9 @@
 
 pub(crate) mod arguments;
 
-use self::arguments::Arguments;
-use compiler_llvm_builder::utils::VERBOSE;
 use std::path::PathBuf;
+
+use self::arguments::Arguments;
 
 /// The default path to the LLVM lock file.
 pub const LLVM_LOCK_DEFAULT_PATH: &str = "LLVM.lock";
@@ -36,7 +36,7 @@ fn strip_leading_backslash(s: String) -> String {
 /// The entry result wrapper.
 ///
 fn main_inner() -> anyhow::Result<()> {
-    if VERBOSE {
+    if compiler_llvm_builder::utils::VERBOSE {
         println!("std::env::args(): {:#?}", std::env::args());
         println!(
             "\nstd::env::args() collected: {}",
@@ -53,25 +53,24 @@ fn main_inner() -> anyhow::Result<()> {
         Arguments::Build {
             debug,
             enable_tests,
-            extra_args,
             enable_coverage,
+            extra_args,
         } => {
-            let mut extra_args_unescaped: Vec<_> = extra_args
+            let extra_args_unescaped: Vec<_> = extra_args
                 .iter()
                 .map(|s| strip_leading_backslash(s.to_string()))
                 .collect::<Vec<_>>();
-            if VERBOSE {
+            if compiler_llvm_builder::utils::VERBOSE {
                 println!("\nextra_args: {:#?}", extra_args);
                 println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
             }
-            if enable_coverage {
-                extra_args_unescaped.push(r"-DLLVM_BUILD_INSTRUMENTED_COVERAGE='On'".to_string());
-                if VERBOSE {
-                    println!("\nargs with coverage: {:#?}", extra_args_unescaped);
-                }
-            }
             let build_type = compiler_llvm_builder::BuildType::from(debug);
-            compiler_llvm_builder::build(build_type, enable_tests, extra_args_unescaped)?;
+            compiler_llvm_builder::build(
+                build_type,
+                enable_tests,
+                enable_coverage,
+                extra_args_unescaped,
+            )?;
         }
         Arguments::Checkout { force } => {
             let lock = compiler_llvm_builder::Lock::try_from(&PathBuf::from("LLVM.lock"))?;

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -30,6 +30,8 @@ fn main() {
 /// The entry result wrapper.
 ///
 fn main_inner() -> anyhow::Result<()> {
+    println!("\nstd::env::args() collected: {}", std::env::args().collect::<Vec<_>>().join(" "));
+    println!("std::env::args(): {:#?}", std::env::args());
     let arguments = Arguments::new();
 
     match arguments {
@@ -42,10 +44,12 @@ fn main_inner() -> anyhow::Result<()> {
             enable_tests,
             extra_args, 
         } => {
+            println!("\nextra_args: {:#?}", extra_args);
             let extra_args_unescaped:Vec<_> = extra_args.iter()
                 .map(|s| unescape(s))
                 .collect::<Result<_, _>>()
                 .unwrap();
+            println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
             let build_type = compiler_llvm_builder::BuildType::from(debug);
             compiler_llvm_builder::build(build_type, enable_tests, extra_args_unescaped)?;
         }

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -4,9 +4,9 @@
 
 pub(crate) mod arguments;
 
-use std::path::PathBuf;
 use self::arguments::Arguments;
 use compiler_llvm_builder::utils::VERBOSE;
+use std::path::PathBuf;
 
 /// The default path to the LLVM lock file.
 pub const LLVM_LOCK_DEFAULT_PATH: &str = "LLVM.lock";
@@ -24,10 +24,9 @@ fn main() {
     }
 }
 
-
 fn strip_leading_backslash(s: String) -> String {
-    if s.starts_with('\\')  {
-        s.strip_prefix('\\').unwrap().to_string() 
+    if s.starts_with('\\') {
+        s.strip_prefix('\\').unwrap().to_string()
     } else {
         s
     }
@@ -39,7 +38,10 @@ fn strip_leading_backslash(s: String) -> String {
 fn main_inner() -> anyhow::Result<()> {
     if VERBOSE {
         println!("std::env::args(): {:#?}", std::env::args());
-        println!("\nstd::env::args() collected: {}", std::env::args().collect::<Vec<_>>().join(" "));
+        println!(
+            "\nstd::env::args() collected: {}",
+            std::env::args().collect::<Vec<_>>().join(" ")
+        );
     }
     let arguments = Arguments::new();
 
@@ -51,9 +53,10 @@ fn main_inner() -> anyhow::Result<()> {
         Arguments::Build {
             debug,
             enable_tests,
-            extra_args, 
+            extra_args,
         } => {
-            let extra_args_unescaped:Vec<_> = extra_args.iter()
+            let extra_args_unescaped: Vec<_> = extra_args
+                .iter()
                 .map(|s| strip_leading_backslash(s.to_string()))
                 .collect::<Vec<_>>();
             if VERBOSE {

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -38,6 +38,7 @@ fn main_inner() -> anyhow::Result<()> {
         Arguments::Build {
             debug,
             enable_tests,
+            extra_args, 
         } => {
             let build_type = compiler_llvm_builder::BuildType::from(debug);
             compiler_llvm_builder::build(build_type, enable_tests)?;

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -41,7 +41,7 @@ fn main_inner() -> anyhow::Result<()> {
             extra_args, 
         } => {
             let build_type = compiler_llvm_builder::BuildType::from(debug);
-            compiler_llvm_builder::build(build_type, enable_tests)?;
+            compiler_llvm_builder::build(build_type, enable_tests, extra_args)?;
         }
         Arguments::Checkout { force } => {
             let lock = compiler_llvm_builder::Lock::try_from(&PathBuf::from("LLVM.lock"))?;

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -5,6 +5,8 @@
 pub(crate) mod arguments;
 
 use std::path::PathBuf;
+use snailquote::unescape;
+
 
 use self::arguments::Arguments;
 
@@ -40,8 +42,12 @@ fn main_inner() -> anyhow::Result<()> {
             enable_tests,
             extra_args, 
         } => {
+            let extra_args_unescaped:Vec<_> = extra_args.iter()
+                .map(|s| unescape(s))
+                .collect::<Result<_, _>>()
+                .unwrap();
             let build_type = compiler_llvm_builder::BuildType::from(debug);
-            compiler_llvm_builder::build(build_type, enable_tests, extra_args)?;
+            compiler_llvm_builder::build(build_type, enable_tests, extra_args_unescaped)?;
         }
         Arguments::Checkout { force } => {
             let lock = compiler_llvm_builder::Lock::try_from(&PathBuf::from("LLVM.lock"))?;

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -5,8 +5,6 @@
 pub(crate) mod arguments;
 
 use std::path::PathBuf;
-use snailquote::unescape;
-
 
 use self::arguments::Arguments;
 
@@ -23,6 +21,15 @@ fn main() {
             eprintln!("Error: {error:?}");
             std::process::exit(1)
         }
+    }
+}
+
+
+fn strip_leading_backslash(s: String) -> String {
+    if s.starts_with('\\')  {
+        s.strip_prefix('\\').unwrap().to_string() 
+    } else {
+        s
     }
 }
 
@@ -46,7 +53,7 @@ fn main_inner() -> anyhow::Result<()> {
         } => {
             println!("\nextra_args: {:#?}", extra_args);
             let extra_args_unescaped:Vec<_> = extra_args.iter()
-                .map(|s| unescape(s).unwrap())
+                .map(|s| strip_leading_backslash(s.to_string()))
                 .collect::<Vec<_>>();
             println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
             let build_type = compiler_llvm_builder::BuildType::from(debug);

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -54,6 +54,7 @@ fn main_inner() -> anyhow::Result<()> {
             debug,
             enable_tests,
             extra_args,
+            enable_coverage,
         } => {
             let extra_args_unescaped: Vec<_> = extra_args
                 .iter()

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -56,13 +56,19 @@ fn main_inner() -> anyhow::Result<()> {
             extra_args,
             enable_coverage,
         } => {
-            let extra_args_unescaped: Vec<_> = extra_args
+            let mut extra_args_unescaped: Vec<_> = extra_args
                 .iter()
                 .map(|s| strip_leading_backslash(s.to_string()))
                 .collect::<Vec<_>>();
             if VERBOSE {
                 println!("\nextra_args: {:#?}", extra_args);
                 println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
+            }
+            if enable_coverage {
+                extra_args_unescaped.push(r"-DLLVM_BUILD_INSTRUMENTED_COVERAGE='On'".to_string());
+                if VERBOSE {
+                    println!("\nargs with coverage: {:#?}", extra_args_unescaped);
+                }
             }
             let build_type = compiler_llvm_builder::BuildType::from(debug);
             compiler_llvm_builder::build(build_type, enable_tests, extra_args_unescaped)?;

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -5,8 +5,8 @@
 pub(crate) mod arguments;
 
 use std::path::PathBuf;
-
 use self::arguments::Arguments;
+use compiler_llvm_builder::utils::VERBOSE;
 
 /// The default path to the LLVM lock file.
 pub const LLVM_LOCK_DEFAULT_PATH: &str = "LLVM.lock";
@@ -37,8 +37,10 @@ fn strip_leading_backslash(s: String) -> String {
 /// The entry result wrapper.
 ///
 fn main_inner() -> anyhow::Result<()> {
-    println!("\nstd::env::args() collected: {}", std::env::args().collect::<Vec<_>>().join(" "));
-    println!("std::env::args(): {:#?}", std::env::args());
+    if VERBOSE {
+        println!("std::env::args(): {:#?}", std::env::args());
+        println!("\nstd::env::args() collected: {}", std::env::args().collect::<Vec<_>>().join(" "));
+    }
     let arguments = Arguments::new();
 
     match arguments {
@@ -51,11 +53,13 @@ fn main_inner() -> anyhow::Result<()> {
             enable_tests,
             extra_args, 
         } => {
-            println!("\nextra_args: {:#?}", extra_args);
             let extra_args_unescaped:Vec<_> = extra_args.iter()
                 .map(|s| strip_leading_backslash(s.to_string()))
                 .collect::<Vec<_>>();
-            println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
+            if VERBOSE {
+                println!("\nextra_args: {:#?}", extra_args);
+                println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
+            }
             let build_type = compiler_llvm_builder::BuildType::from(debug);
             compiler_llvm_builder::build(build_type, enable_tests, extra_args_unescaped)?;
         }

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -46,9 +46,8 @@ fn main_inner() -> anyhow::Result<()> {
         } => {
             println!("\nextra_args: {:#?}", extra_args);
             let extra_args_unescaped:Vec<_> = extra_args.iter()
-                .map(|s| unescape(s))
-                .collect::<Result<_, _>>()
-                .unwrap();
+                .map(|s| unescape(s).unwrap())
+                .collect::<Vec<_>>();
             println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
             let build_type = compiler_llvm_builder::BuildType::from(debug);
             compiler_llvm_builder::build(build_type, enable_tests, extra_args_unescaped)?;


### PR DESCRIPTION
Add a new option:
> --extra-args <extra-args>...    Extra arguments to pass to CMake. A leading backslash will be unescaped

Tested on Ubuntu 22.04.1 LTS Jammy Jellyfish on x86_64, our [GitHub Action](https://github.com/matter-labs/compiler-llvm/actions/runs/5159734660/jobs/9295708943), and MacOS 12.6.2 21G320 on M1 Max
Let me know if I should create some VMs to test other platforms.