### PR TITLE
feat: add support for compiler cache (ccache)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,13 @@ pub fn build(
                 anyhow::bail!("Unsupported target environment for x86_64 and Linux");
             }
         } else if cfg!(target_os = "macos") {
-            platforms::x86_64_macos::build(build_type, enable_tests, enable_coverage, extra_args, use_ccache)?;
+            platforms::x86_64_macos::build(
+                build_type,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+                use_ccache,
+            )?;
         } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
             platforms::x86_64_windows_gnu::build(
                 build_type,
@@ -166,7 +172,13 @@ pub fn build(
                 anyhow::bail!("Unsupported target environment for aarch64 and Linux");
             }
         } else if cfg!(target_os = "macos") {
-            platforms::aarch64_macos::build(build_type, enable_tests, enable_coverage, extra_args, use_ccache)?;
+            platforms::aarch64_macos::build(
+                build_type,
+                enable_tests,
+                enable_coverage,
+                extra_args,
+                use_ccache,
+            )?;
         } else {
             anyhow::bail!("Unsupported target OS for aarch64");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
 
@@ -117,6 +118,7 @@ pub fn build(
                     enable_tests,
                     enable_coverage,
                     extra_args,
+                    use_ccache,
                 )?;
             } else if cfg!(target_env = "musl") {
                 platforms::x86_64_linux_musl::build(
@@ -124,18 +126,20 @@ pub fn build(
                     enable_tests,
                     enable_coverage,
                     extra_args,
+                    use_ccache,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for x86_64 and Linux");
             }
         } else if cfg!(target_os = "macos") {
-            platforms::x86_64_macos::build(build_type, enable_tests, enable_coverage, extra_args)?;
+            platforms::x86_64_macos::build(build_type, enable_tests, enable_coverage, extra_args, use_ccache)?;
         } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
             platforms::x86_64_windows_gnu::build(
                 build_type,
                 enable_tests,
                 enable_coverage,
                 extra_args,
+                use_ccache,
             )?;
         } else {
             anyhow::bail!("Unsupported target OS for x86_64");
@@ -148,6 +152,7 @@ pub fn build(
                     enable_tests,
                     enable_coverage,
                     extra_args,
+                    use_ccache,
                 )?;
             } else if cfg!(target_env = "musl") {
                 platforms::aarch64_linux_musl::build(
@@ -155,12 +160,13 @@ pub fn build(
                     enable_tests,
                     enable_coverage,
                     extra_args,
+                    use_ccache,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for aarch64 and Linux");
             }
         } else if cfg!(target_os = "macos") {
-            platforms::aarch64_macos::build(build_type, enable_tests, enable_coverage, extra_args)?;
+            platforms::aarch64_macos::build(build_type, enable_tests, enable_coverage, extra_args, use_ccache)?;
         } else {
             anyhow::bail!("Unsupported target OS for aarch64");
         }

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -53,9 +53,7 @@ pub fn build(
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM building cmake",
     )?;
     crate::utils::ninja(llvm_build_final.as_ref())?;

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -15,6 +15,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -51,7 +52,10 @@ pub fn build(
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-            .args(extra_args),
+            .args(extra_args)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM building cmake",
     )?;
     crate::utils::ninja(llvm_build_final.as_ref())?;

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -16,6 +16,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("wget")?;
     crate::utils::check_presence("tar")?;
@@ -46,6 +47,7 @@ pub fn build(
         llvm_module_llvm.as_path(),
         llvm_build_crt.as_path(),
         llvm_target_crt.as_path(),
+        use_ccache,
     )?;
     build_host(
         llvm_module_llvm.as_path(),
@@ -53,6 +55,7 @@ pub fn build(
         llvm_target_host.as_path(),
         musl_target.as_path(),
         llvm_target_crt.as_path(),
+        use_ccache,
     )?;
     build_target(
         build_type,
@@ -64,6 +67,7 @@ pub fn build(
         enable_tests,
         enable_coverage,
         extra_args,
+        use_ccache,
     )?;
 
     Ok(())
@@ -179,6 +183,7 @@ fn build_crt(
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::command(
         Command::new("cmake")
@@ -216,7 +221,10 @@ fn build_crt(
                 "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
                 "-DCOMPILER_RT_BUILD_ORC='Off'",
             ])
-            .args(crate::platforms::SHARED_BUILD_OPTS),
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "CRT building cmake",
     )?;
 
@@ -240,6 +248,7 @@ fn build_host(
     target_directory: &Path,
     musl_target_directory: &Path,
     crt_target_directory: &Path,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::command(
         Command::new("cmake")
@@ -297,7 +306,10 @@ fn build_host(
                 "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='aarch64'",
                 "-DCOMPILER_RT_DEFAULT_TARGET_ONLY='On'",
             ])
-            .args(crate::platforms::SHARED_BUILD_OPTS),
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM host building cmake",
     )?;
 
@@ -340,6 +352,7 @@ fn build_target(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -386,7 +399,10 @@ fn build_target(
                 enable_coverage,
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
-            .args(extra_args),
+            .args(extra_args)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM target building cmake",
     )?;
 

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -16,7 +16,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
-    use_ccache: bool
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("wget")?;
     crate::utils::check_presence("tar")?;
@@ -222,9 +222,7 @@ fn build_crt(
                 "-DCOMPILER_RT_BUILD_ORC='Off'",
             ])
             .args(crate::platforms::SHARED_BUILD_OPTS)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "CRT building cmake",
     )?;
 
@@ -307,9 +305,7 @@ fn build_host(
                 "-DCOMPILER_RT_DEFAULT_TARGET_ONLY='On'",
             ])
             .args(crate::platforms::SHARED_BUILD_OPTS)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM host building cmake",
     )?;
 
@@ -400,9 +396,7 @@ fn build_target(
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(extra_args)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM target building cmake",
     )?;
 

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -15,6 +15,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
@@ -46,7 +47,10 @@ pub fn build(
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-            .args(extra_args),
+            .args(extra_args)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -48,9 +48,7 @@ pub fn build(
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -82,5 +82,5 @@ pub fn shared_build_opts_ccache(use_ccache: bool) -> Vec<String> {
         ]
     } else {
         vec![]
-    }
+    };
 }

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -75,12 +75,12 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
 
 /// Use of compiler cache (ccache) to speed up the build process
 pub fn shared_build_opts_ccache(use_ccache: bool) -> Vec<String> {
-    return if use_ccache {
+    if use_ccache {
         vec![
             "-DCMAKE_C_COMPILER_LAUNCHER=ccache".to_string(),
             "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache".to_string(),
         ]
     } else {
         vec![]
-    };
+    }
 }

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -72,3 +72,15 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
         if enabled { "On" } else { "Off" },
     )]
 }
+
+/// Use of compiler cache (ccache) to speed up the build process
+pub fn shared_build_opts_ccache(use_ccache: bool) -> Vec<String> {
+    return if use_ccache {
+        vec![
+            "-DCMAKE_C_COMPILER_LAUNCHER=ccache".to_string(),
+            "-DCMAKE_CXX_COMPILER_LAUNCHER=ccache".to_string(),
+        ]
+    } else {
+        vec![]
+    }
+}

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -50,9 +50,7 @@ pub fn build(
             .args(crate::platforms::shared_build_opts_coverage(
                 enable_coverage,
             ))
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            ))
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args),

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -15,6 +15,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -48,6 +49,9 @@ pub fn build(
             .args(crate::platforms::shared_build_opts_tests(enable_tests))
             .args(crate::platforms::shared_build_opts_coverage(
                 enable_coverage,
+            ))
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -67,7 +67,7 @@ pub fn build(
         enable_tests,
         enable_coverage,
         extra_args,
-        use_ccache
+        use_ccache,
     )?;
 
     Ok(())
@@ -222,9 +222,7 @@ fn build_crt(
                 "-DCOMPILER_RT_BUILD_ORC='Off'",
             ])
             .args(crate::platforms::SHARED_BUILD_OPTS)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "CRT building cmake",
     )?;
 
@@ -307,9 +305,7 @@ fn build_host(
                 "-DCOMPILER_RT_DEFAULT_TARGET_ONLY='On'",
             ])
             .args(crate::platforms::SHARED_BUILD_OPTS)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM host building cmake",
     )?;
 
@@ -400,9 +396,7 @@ fn build_target(
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(extra_args)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM target building cmake",
     )?;
 

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -16,6 +16,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("wget")?;
     crate::utils::check_presence("tar")?;
@@ -46,6 +47,7 @@ pub fn build(
         llvm_module_llvm.as_path(),
         llvm_build_crt.as_path(),
         llvm_target_crt.as_path(),
+        use_ccache,
     )?;
     build_host(
         llvm_module_llvm.as_path(),
@@ -53,6 +55,7 @@ pub fn build(
         llvm_target_host.as_path(),
         musl_target.as_path(),
         llvm_target_crt.as_path(),
+        use_ccache,
     )?;
     build_target(
         build_type,
@@ -64,6 +67,7 @@ pub fn build(
         enable_tests,
         enable_coverage,
         extra_args,
+        use_ccache
     )?;
 
     Ok(())
@@ -179,6 +183,7 @@ fn build_crt(
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::command(
         Command::new("cmake")
@@ -216,7 +221,10 @@ fn build_crt(
                 "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
                 "-DCOMPILER_RT_BUILD_ORC='Off'",
             ])
-            .args(crate::platforms::SHARED_BUILD_OPTS),
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "CRT building cmake",
     )?;
 
@@ -240,6 +248,7 @@ fn build_host(
     target_directory: &Path,
     musl_target_directory: &Path,
     crt_target_directory: &Path,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::command(
         Command::new("cmake")
@@ -297,7 +306,10 @@ fn build_host(
                 "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='x86_64'",
                 "-DCOMPILER_RT_DEFAULT_TARGET_ONLY='On'",
             ])
-            .args(crate::platforms::SHARED_BUILD_OPTS),
+            .args(crate::platforms::SHARED_BUILD_OPTS)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM host building cmake",
     )?;
 
@@ -340,6 +352,7 @@ fn build_target(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -386,7 +399,10 @@ fn build_target(
                 enable_coverage,
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
-            .args(extra_args),
+            .args(extra_args)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM target building cmake",
     )?;
 

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -15,6 +15,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
@@ -46,7 +47,10 @@ pub fn build(
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-            .args(extra_args),
+            .args(extra_args)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -48,9 +48,7 @@ pub fn build(
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -16,6 +16,7 @@ pub fn build(
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
+    use_ccache: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -55,7 +56,10 @@ pub fn build(
             ))
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
-            .args(extra_args),
+            .args(extra_args)
+            .args(crate::platforms::shared_build_opts_ccache(
+                use_ccache
+            )),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -57,9 +57,7 @@ pub fn build(
             .args(crate::platforms::SHARED_BUILD_OPTS)
             .args(crate::platforms::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args)
-            .args(crate::platforms::shared_build_opts_ccache(
-                use_ccache
-            )),
+            .args(crate::platforms::shared_build_opts_ccache(use_ccache)),
         "LLVM building cmake",
     )?;
 

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -27,6 +27,9 @@ pub enum Arguments {
         /// A leading backslash will be unescaped.
         #[structopt(long = "extra-args", multiple = true)]
         extra_args: Vec<String>,
+        /// Whether to use compiler cache (ccache) to speed-up builds
+        #[structopt(long = "use-ccache")]
+        use_ccache: bool,
     },
     /// Checkout the branch specified in `LLVM.lock`.
     Checkout {

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -27,7 +27,7 @@ pub enum Arguments {
         /// A leading backslash will be unescaped.
         #[structopt(long = "extra-args", multiple = true)]
         extra_args: Vec<String>,
-        /// Whether to use compiler cache (ccache) to speed-up builds
+        /// Whether to use compiler cache (ccache) to speed-up builds.
         #[structopt(long = "use-ccache")]
         use_ccache: bool,
     },

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -5,9 +5,7 @@
 pub(crate) mod arguments;
 
 use anyhow::Context;
-use compiler_llvm_builder::utils;
 use std::path::PathBuf;
-use utils::check_presence;
 
 use self::arguments::Arguments;
 
@@ -53,7 +51,7 @@ fn main_inner() -> anyhow::Result<()> {
             use_ccache,
         } => {
             if use_ccache {
-                check_presence("ccache")?;
+                compiler_llvm_builder::utils::check_presence("ccache")?;
             }
             let extra_args_unescaped: Vec<String> = extra_args
                 .iter()

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod arguments;
 
+use anyhow::Context;
 use compiler_llvm_builder::utils;
 use std::path::PathBuf;
 use utils::check_presence;
@@ -81,7 +82,8 @@ fn main_inner() -> anyhow::Result<()> {
             compiler_llvm_builder::checkout(lock, force)?;
         }
         Arguments::Clean => {
-            compiler_llvm_builder::clean()?;
+            compiler_llvm_builder::clean()
+                .with_context(|| "Unable to remove target LLVM directory")?;
         }
     }
 

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -74,7 +74,7 @@ fn main_inner() -> anyhow::Result<()> {
                 enable_tests,
                 enable_coverage,
                 extra_args_unescaped,
-                use_ccache
+                use_ccache,
             )?;
         }
         Arguments::Checkout { force } => {

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -82,8 +82,7 @@ fn main_inner() -> anyhow::Result<()> {
             compiler_llvm_builder::checkout(lock, force)?;
         }
         Arguments::Clean => {
-            compiler_llvm_builder::clean()
-                .with_context(|| "Unable to remove target LLVM directory")?;
+            compiler_llvm_builder::clean()?;
         }
     }
 

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -6,6 +6,8 @@ pub(crate) mod arguments;
 
 use anyhow::Context;
 use std::path::PathBuf;
+use compiler_llvm_builder::utils;
+use utils::check_presence;
 
 use self::arguments::Arguments;
 
@@ -48,7 +50,11 @@ fn main_inner() -> anyhow::Result<()> {
             enable_tests,
             enable_coverage,
             extra_args,
+            use_ccache,
         } => {
+            if use_ccache {
+                check_presence("ccache")?;
+            }
             let extra_args_unescaped: Vec<String> = extra_args
                 .iter()
                 .map(|argument| {
@@ -68,6 +74,7 @@ fn main_inner() -> anyhow::Result<()> {
                 enable_tests,
                 enable_coverage,
                 extra_args_unescaped,
+                use_ccache
             )?;
         }
         Arguments::Checkout { force } => {

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -4,9 +4,8 @@
 
 pub(crate) mod arguments;
 
-use anyhow::Context;
-use std::path::PathBuf;
 use compiler_llvm_builder::utils;
+use std::path::PathBuf;
 use utils::check_presence;
 
 use self::arguments::Arguments;


### PR DESCRIPTION
# What ❔

Add support for [compiler cache](https://ccache.dev/) during the build process for all targets.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

It helps to significantly increase compilation speed by recompiling only changed source files. It can be used locally or in CI to get significant speed-up for our LLVM backend builds.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
