### PR TITLE
fix: disable assertions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -114,10 +114,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - name: "Linux x86 gnu"
+          - name: "Linux x86_64 gnu"
             runner: matterlabs-ci-runner
             target: "x86_64-unknown-linux-gnu"
-          - name: "Linux arm64"
+          - name: "Linux aarch64 gnu"
+            runner: matterlabs-ci-runner-arm
+            target: "aarch64-unknown-linux-gnu"
+          - name: "Linux x86_64 musl"
+            runner: matterlabs-ci-runner
+            target: "x86_64-unknown-linux-musl"
+          - name: "Linux arm64 musl"
             runner: matterlabs-ci-runner-arm
             target: "aarch64-unknown-linux-musl"
             rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-15/lib/clang/15.0.7/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
@@ -137,7 +143,7 @@ jobs:
       - name: Test
         run: |
           cargo install cargo2junit
-          cargo test --no-fail-fast -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+          cargo test --target ${{ matrix.target }} --no-fail-fast -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
       - name: Upload test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.19"
+version = "1.0.20"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.19"
+version = "1.0.20"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]

--- a/src/build_type.rs
+++ b/src/build_type.rs
@@ -5,7 +5,7 @@
 ///
 /// The zkEVM LLVM build type.
 ///
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum BuildType {
     /// The debug build.
     Debug,

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -68,6 +68,9 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                build_type == BuildType::Debug,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -421,6 +421,9 @@ fn build_target(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                build_type == BuildType::Debug,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -63,6 +63,9 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                build_type == BuildType::Debug,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -3,7 +3,7 @@
 //!
 
 /// The build options shared by all platforms.
-pub const SHARED_BUILD_OPTS: [&str; 19] = [
+pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCLANG_VENDOR='Matter Labs'",
     "-DCLANG_REPOSITORY_STRING='origin'",
@@ -22,7 +22,6 @@ pub const SHARED_BUILD_OPTS: [&str; 19] = [
     "-DLLVM_ENABLE_TERMINFO='Off'",
     "-DLLVM_ENABLE_LIBEDIT='Off'",
     "-DLLVM_ENABLE_LIBPFM='Off'",
-    "-DLLVM_ENABLE_ASSERTIONS='On'",
 ];
 
 /// The build options shared by all platforms except MUSL.

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -33,6 +33,14 @@ pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 5] = [
     "-DLLVM_INCLUDE_RUNTIMES='Off'",
 ];
 
+/// The build options to enable assertions.
+pub fn shared_build_opts_assertions(enabled: bool) -> Vec<String> {
+    vec![format!(
+        "-DLLVM_ENABLE_ASSERTIONS='{}'",
+        if enabled { "On" } else { "Off" },
+    )]
+}
+
 /// The LLVM tests build options shared by all platforms.
 pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {
     vec![

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -68,7 +68,10 @@ pub fn build(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
-            .args(extra_args),
+            .args(extra_args)
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                build_type == BuildType::Debug,
+            )),
         "LLVM building cmake",
     )?;
     crate::utils::ninja(llvm_build_final.as_ref())?;

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -421,6 +421,9 @@ fn build_target(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                build_type == BuildType::Debug,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -63,6 +63,9 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                build_type == BuildType::Debug,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -72,6 +72,9 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_assertions(
+                build_type == BuildType::Debug,
             )),
         "LLVM building cmake",
     )?;

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -74,46 +74,6 @@ fn clone_build_and_clean() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Tests the clone, build, and clean process of the LLVM repository with musl target.
-///
-/// This test verifies that the LLVM repository can be cloned, built, and cleaned for musl using 2-staged build.
-///
-/// # Errors
-///
-/// Returns an error if any of the test assertions fail or if there is an error while executing
-/// the build or clean commands.
-///
-/// # Returns
-///
-/// Returns `Ok(())` if the test passes.
-#[rstest]
-#[timeout(std::time::Duration::from_secs(10000))]
-fn clone_build_and_clean_musl() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
-    let test_dir = lockfile
-        .parent()
-        .expect("Lockfile parent dir does not exist");
-    cmd.current_dir(test_dir);
-    cmd.arg("clone");
-    cmd.assert()
-        .success()
-        .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
-    let mut build_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    build_cmd.current_dir(test_dir);
-    build_cmd
-        .arg("build")
-        .arg("--target aarch64-unknown-linux-musl")
-        .assert()
-        .success()
-        .stdout(predicate::str::is_match("Installing:.*").unwrap());
-    let mut clean_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    clean_cmd.current_dir(test_dir);
-    clean_cmd.arg("clean");
-    clean_cmd.assert().success();
-    Ok(())
-}
-
 /// Tests the debug build process of the LLVM repository with tests and coverage enabled.
 ///
 /// This test verifies that the LLVM repository can be successfully cloned and built in debug mode

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -74,6 +74,46 @@ fn clone_build_and_clean() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests the clone, build, and clean process of the LLVM repository with musl target.
+///
+/// This test verifies that the LLVM repository can be cloned, built, and cleaned for musl using 2-staged build.
+///
+/// # Errors
+///
+/// Returns an error if any of the test assertions fail or if there is an error while executing
+/// the build or clean commands.
+///
+/// # Returns
+///
+/// Returns `Ok(())` if the test passes.
+#[rstest]
+#[timeout(std::time::Duration::from_secs(10000))]
+fn clone_build_and_clean_musl() -> anyhow::Result<()> {
+    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let test_dir = lockfile
+        .parent()
+        .expect("Lockfile parent dir does not exist");
+    cmd.current_dir(test_dir);
+    cmd.arg("clone");
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
+    let mut build_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    build_cmd.current_dir(test_dir);
+    build_cmd
+        .arg("build")
+        .arg("--target aarch64-unknown-linux-musl")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("Installing:.*").unwrap());
+    let mut clean_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    clean_cmd.current_dir(test_dir);
+    clean_cmd.arg("clean");
+    clean_cmd.assert().success();
+    Ok(())
+}
+
 /// Tests the debug build process of the LLVM repository with tests and coverage enabled.
 ///
 /// This test verifies that the LLVM repository can be successfully cloned and built in debug mode


### PR DESCRIPTION
# What ❔

Disables assertions for cross-compilation targets to unblock Linux Musl builds

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

See [CPR-1592](https://linear.app/matterlabs/issue/CPR-1592/linux-musl-llvm-targets-cannot-be-built-with-assertions) for more info

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Documentation comments have been added / updated.
- [ ] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
