### PR TITLE
feat: add separate explicit option to enable assertions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
 
@@ -122,6 +123,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    enable_assertions,
                 )?;
             } else if cfg!(target_env = "musl") {
                 platforms::x86_64_linux_musl::build(
@@ -131,6 +133,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    enable_assertions,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for x86_64 and Linux");
@@ -143,6 +146,7 @@ pub fn build(
                 enable_coverage,
                 extra_args,
                 use_ccache,
+                enable_assertions,
             )?;
         } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
             platforms::x86_64_windows_gnu::build(
@@ -152,6 +156,7 @@ pub fn build(
                 enable_coverage,
                 extra_args,
                 use_ccache,
+                enable_assertions,
             )?;
         } else {
             anyhow::bail!("Unsupported target OS for x86_64");
@@ -166,6 +171,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    enable_assertions,
                 )?;
             } else if cfg!(target_env = "musl") {
                 platforms::aarch64_linux_musl::build(
@@ -175,6 +181,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    enable_assertions,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for aarch64 and Linux");
@@ -187,6 +194,7 @@ pub fn build(
                 enable_coverage,
                 extra_args,
                 use_ccache,
+                enable_assertions,
             )?;
         } else {
             anyhow::bail!("Unsupported target OS for aarch64");

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -18,6 +18,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -70,7 +71,7 @@ pub fn build(
                 use_ccache,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
-                build_type == BuildType::Debug,
+                enable_assertions,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -19,6 +19,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("wget")?;
     crate::utils::check_presence("tar")?;
@@ -72,6 +73,7 @@ pub fn build(
         enable_coverage,
         extra_args,
         use_ccache,
+        enable_assertions,
     )?;
 
     Ok(())
@@ -367,6 +369,7 @@ fn build_target(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -423,7 +426,7 @@ fn build_target(
                 use_ccache,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
-                build_type == BuildType::Debug,
+                enable_assertions,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -18,6 +18,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
@@ -65,7 +66,7 @@ pub fn build(
                 use_ccache,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
-                build_type == BuildType::Debug,
+                enable_assertions,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -18,6 +18,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -70,7 +71,7 @@ pub fn build(
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_assertions(
-                build_type == BuildType::Debug,
+                enable_assertions,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -19,6 +19,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("wget")?;
     crate::utils::check_presence("tar")?;
@@ -72,6 +73,7 @@ pub fn build(
         enable_coverage,
         extra_args,
         use_ccache,
+        enable_assertions,
     )?;
 
     Ok(())
@@ -367,6 +369,7 @@ fn build_target(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -423,7 +426,7 @@ fn build_target(
                 use_ccache,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
-                build_type == BuildType::Debug,
+                enable_assertions,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -18,6 +18,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("ninja")?;
@@ -65,7 +66,7 @@ pub fn build(
                 use_ccache,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
-                build_type == BuildType::Debug,
+                enable_assertions,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -19,6 +19,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    enable_assertions: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -74,7 +75,7 @@ pub fn build(
                 use_ccache,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
-                build_type == BuildType::Debug,
+                enable_assertions,
             )),
         "LLVM building cmake",
     )?;

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -33,6 +33,9 @@ pub enum Arguments {
         /// Whether to use compiler cache (ccache) to speed-up builds.
         #[structopt(long = "use-ccache")]
         use_ccache: bool,
+        /// Whether to build with assertions enabled or not.
+        #[structopt(long = "enable-assertions")]
+        enable_assertions: bool,
     },
     /// Checkout the branch specified in `LLVM.lock`.
     Checkout {

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -52,6 +52,7 @@ fn main_inner() -> anyhow::Result<()> {
             enable_coverage,
             extra_args,
             use_ccache,
+            enable_assertions,
         } => {
             let build_type = compiler_llvm_builder::BuildType::from(debug);
 
@@ -87,6 +88,7 @@ fn main_inner() -> anyhow::Result<()> {
                 enable_coverage,
                 extra_args_unescaped,
                 use_ccache,
+                enable_assertions,
             )?;
         }
         Arguments::Checkout { force } => {


### PR DESCRIPTION
# What ❔

Fixes [CPR-1593](https://linear.app/matterlabs/issue/CPR-1593/add-separate-option-to-enable-assertions-to-llvm-builder)

Adds an explicit option `--enable-assertions` to enable/disable assertions in an agile manner.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

 This will let us to have release builds with assertions enabled if required that was not possible before when the behavior was defined by `debug` mode.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
