### PR TITLE
feat: add fast shallow clone support

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -141,18 +141,24 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+
       - name: Build
         run: |
           rustup target add ${{ matrix.target }}
           cargo build --release
+
       - name: Test
-        shell: bash
-        run: |
-          cargo install cargo2junit
-          # Disable unsupported tests
-          [[ ${{ matrix.target }} != *musl* ]] && INCLUDE_IGNORED="--include-ignored"
-          cargo test --target ${{ matrix.target }} --no-fail-fast -- -Z unstable-options --format json ${INCLUDE_IGNORED} \
-            | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+        uses: nick-fields/retry@v2
+        with:
+          timeout_minutes: 120
+          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
+          command: |
+            cargo install cargo2junit
+            # Disable unsupported tests
+            [[ ${{ matrix.target }} != *musl* ]] && INCLUDE_IGNORED="--include-ignored"
+            cargo test --target ${{ matrix.target }} --no-fail-fast -- -Z unstable-options --format json ${INCLUDE_IGNORED} \
+              | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+
       - name: Upload test results
         if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2.12.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,7 +101,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.20"
+version = "1.0.21"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.20"
+version = "1.0.21"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 ///
 /// Executes the LLVM repository cloning.
 ///
-pub fn clone(lock: Lock, shallow: bool) -> anyhow::Result<()> {
+pub fn clone(lock: Lock, deep: bool) -> anyhow::Result<()> {
     utils::check_presence("git")?;
 
     let destination_path = PathBuf::from(LLVMPath::DIRECTORY_LLVM_SOURCE);
@@ -31,7 +31,7 @@ pub fn clone(lock: Lock, shallow: bool) -> anyhow::Result<()> {
     }
 
     let mut clone_args = vec!["clone", "--branch", lock.branch.as_str()];
-    if shallow {
+    if !deep {
         clone_args.push("--depth");
         clone_args.push("1");
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::process::Command;
 ///
 /// Executes the LLVM repository cloning.
 ///
-pub fn clone(lock: Lock) -> anyhow::Result<()> {
+pub fn clone(lock: Lock, shallow: bool) -> anyhow::Result<()> {
     utils::check_presence("git")?;
 
     let destination_path = PathBuf::from(LLVMPath::DIRECTORY_LLVM_SOURCE);
@@ -30,14 +30,17 @@ pub fn clone(lock: Lock) -> anyhow::Result<()> {
         );
     }
 
+    let mut clone_args = vec!["clone", "--branch", lock.branch.as_str()];
+    if shallow {
+        clone_args.push("--depth");
+        clone_args.push("1");
+    }
+
     utils::command(
-        Command::new("git").args([
-            "clone",
-            "--branch",
-            lock.branch.as_str(),
-            lock.url.as_str(),
-            destination_path.to_string_lossy().as_ref(),
-        ]),
+        Command::new("git")
+            .args(clone_args)
+            .arg(lock.url.as_str())
+            .arg(destination_path.to_string_lossy().as_ref()),
         "LLVM repository cloning",
     )?;
 

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -12,9 +12,9 @@ use structopt::StructOpt;
 pub enum Arguments {
     /// Clone the branch specified in `LLVM.lock`.
     Clone {
-        /// Use fast shallow clone with depth 1.
-        #[structopt(long = "shallow")]
-        shallow: bool,
+        /// Clone with full commits history.
+        #[structopt(long)]
+        deep: bool,
     },
     /// Build the LLVM framework.
     Build {

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -11,7 +11,11 @@ use structopt::StructOpt;
 #[structopt(name = "llvm-builder", about = "The zkEVM LLVM framework builder")]
 pub enum Arguments {
     /// Clone the branch specified in `LLVM.lock`.
-    Clone,
+    Clone {
+        /// Use fast shallow clone with depth 1.
+        #[structopt(long = "shallow")]
+        shallow: bool,
+    },
     /// Build the LLVM framework.
     Build {
         /// Whether to build the 'Debug' version.

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -41,9 +41,9 @@ fn main_inner() -> anyhow::Result<()> {
     let arguments = Arguments::new();
 
     match arguments {
-        Arguments::Clone => {
+        Arguments::Clone { shallow } => {
             let lock = compiler_llvm_builder::Lock::try_from(&PathBuf::from("LLVM.lock"))?;
-            compiler_llvm_builder::clone(lock)?;
+            compiler_llvm_builder::clone(lock, shallow)?;
         }
         Arguments::Build {
             debug,

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -41,9 +41,9 @@ fn main_inner() -> anyhow::Result<()> {
     let arguments = Arguments::new();
 
     match arguments {
-        Arguments::Clone { shallow } => {
+        Arguments::Clone { deep } => {
             let lock = compiler_llvm_builder::Lock::try_from(&PathBuf::from("LLVM.lock"))?;
-            compiler_llvm_builder::clone(lock, shallow)?;
+            compiler_llvm_builder::clone(lock, deep)?;
         }
         Arguments::Build {
             debug,

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -37,6 +37,37 @@ fn clone() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests the shallow cloning process of the LLVM repository using a specific branch and reference.
+///
+/// This test verifies that the LLVM repository can be successfully cloned using a specific branch
+/// and reference with --shallow option.
+///
+/// # Errors
+///
+/// Returns an error if any of the test assertions fail or if there is an error while executing
+/// the clone command.
+///
+/// # Returns
+///
+/// Returns `Ok(())` if the test passes.
+fn clone_shallow() -> anyhow::Result<()> {
+    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let test_dir = lockfile
+        .parent()
+        .expect("Lockfile parent dir does not exist");
+    cmd.current_dir(test_dir);
+    cmd.arg("clone");
+    cmd.arg("--shallow");
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::contains(format!(
+            "HEAD is now at {}",
+            common::ERA_LLVM_REPO_TEST_REF
+        )));
+    Ok(())
+}
+
 /// Tests the cloning process of the LLVM repository using an invalid reference.
 ///
 /// This test verifies that attempting to clone the LLVM repository using an invalid reference

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -37,10 +37,10 @@ fn clone() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Tests the shallow cloning process of the LLVM repository using a specific branch and reference.
+/// Tests the full cloning process of the LLVM repository using a specific branch and reference.
 ///
 /// This test verifies that the LLVM repository can be successfully cloned using a specific branch
-/// and reference with --shallow option.
+/// and reference with --deep option.
 ///
 /// # Errors
 ///
@@ -50,7 +50,7 @@ fn clone() -> anyhow::Result<()> {
 /// # Returns
 ///
 /// Returns `Ok(())` if the test passes.
-fn clone_shallow() -> anyhow::Result<()> {
+fn clone_deep() -> anyhow::Result<()> {
     let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
     let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
     let test_dir = lockfile
@@ -58,7 +58,7 @@ fn clone_shallow() -> anyhow::Result<()> {
         .expect("Lockfile parent dir does not exist");
     cmd.current_dir(test_dir);
     cmd.arg("clone");
-    cmd.arg("--shallow");
+    cmd.arg("--deep");
     cmd.assert()
         .success()
         .stderr(predicate::str::contains(format!(


### PR DESCRIPTION
# What ❔

Fixes [CPR-1589](https://linear.app/matterlabs/issue/CPR-1589/optimize-clone-operation-of-zkevm-llvm-builder)

Adds `--shallow` option to make fast clones.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

There are many places in CI where we don't need to clone with the whole history and spend >4m or even more for that. Sometimes, we want just the fastest clone possible. More info about different clone types and analysis are available in [CPR-1589](https://linear.app/matterlabs/issue/CPR-1589/optimize-clone-operation-of-zkevm-llvm-builder).

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
