### PR TITLE
fix: build the EVM target by default

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub use self::llvm_path::LLVMPath;
 pub use self::lock::Lock;
 pub use self::platforms::Platform;
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -107,7 +108,7 @@ pub fn checkout(lock: Lock, force: bool) -> anyhow::Result<()> {
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -2,6 +2,7 @@
 //! The zkEVM LLVM arm64 `linux-gnu` builder.
 //!
 
+use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
@@ -13,7 +14,7 @@ use crate::platforms::Platform;
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -2,6 +2,7 @@
 //! The zkEVM LLVM arm64 `linux-musl` builder.
 //!
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
@@ -14,7 +15,7 @@ use crate::platforms::Platform;
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -186,13 +187,13 @@ fn build_musl(build_directory: &Path, target_directory: &Path) -> anyhow::Result
 /// The `crt` building sequence.
 ///
 fn build_crt(
-    mut targets: Vec<Platform>,
+    mut targets: HashSet<Platform>,
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,
     use_ccache: bool,
 ) -> anyhow::Result<()> {
-    targets.insert(0, Platform::AArch64);
+    targets.insert(Platform::AArch64);
 
     crate::utils::command(
         Command::new("cmake")
@@ -359,7 +360,7 @@ fn build_host(
 #[allow(clippy::too_many_arguments)]
 fn build_target(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -2,6 +2,7 @@
 //! The zkEVM LLVM arm64 `macos-aarch64` builder.
 //!
 
+use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
@@ -13,7 +14,7 @@ use crate::platforms::Platform;
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -2,6 +2,7 @@
 //! The zkEVM LLVM amd64 `linux-gnu` builder.
 //!
 
+use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
@@ -13,7 +14,7 @@ use crate::platforms::Platform;
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -2,6 +2,7 @@
 //! The zkEVM LLVM amd64 `linux-musl` builder.
 //!
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
@@ -14,7 +15,7 @@ use crate::platforms::Platform;
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -186,13 +187,13 @@ fn build_musl(build_directory: &Path, target_directory: &Path) -> anyhow::Result
 /// The `crt` building sequence.
 ///
 fn build_crt(
-    mut targets: Vec<Platform>,
+    mut targets: HashSet<Platform>,
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,
     use_ccache: bool,
 ) -> anyhow::Result<()> {
-    targets.push(Platform::X86);
+    targets.insert(Platform::X86);
 
     crate::utils::command(
         Command::new("cmake")
@@ -359,7 +360,7 @@ fn build_host(
 #[allow(clippy::too_many_arguments)]
 fn build_target(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -2,6 +2,7 @@
 //! The zkEVM LLVM amd64 `macos` builder.
 //!
 
+use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
@@ -13,7 +14,7 @@ use crate::platforms::Platform;
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -2,6 +2,7 @@
 //! The zkEVM LLVM amd64 `windows-gnu` builder.
 //!
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
 
@@ -14,7 +15,7 @@ use crate::platforms::Platform;
 ///
 pub fn build(
     build_type: BuildType,
-    targets: Vec<Platform>,
+    targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -4,6 +4,7 @@
 
 pub(crate) mod arguments;
 
+use std::collections::HashSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -59,9 +60,10 @@ fn main_inner() -> anyhow::Result<()> {
             let mut targets = targets
                 .into_iter()
                 .map(|target| compiler_llvm_builder::Platform::from_str(target.as_str()))
-                .collect::<Result<Vec<compiler_llvm_builder::Platform>, String>>()
+                .collect::<Result<HashSet<compiler_llvm_builder::Platform>, String>>()
                 .map_err(|platform| anyhow::anyhow!("Unknown platform `{}`", platform))?;
-            targets.insert(0, compiler_llvm_builder::Platform::EraVM);
+            targets.insert(compiler_llvm_builder::Platform::EraVM);
+            targets.insert(compiler_llvm_builder::Platform::EVM);
 
             let extra_args_unescaped: Vec<String> = extra_args
                 .iter()


### PR DESCRIPTION
# What ❔

Adds the `EVM` target to the list of targets built by default.

## Why ❔

It will prevents us from adding `--targets EVM` to every single place where `zkevm-llvm` is used.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
