### PR TITLE
chore: fix library duplication warnings for macos builds

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -80,6 +80,7 @@ jobs:
   build-and-test-macos:
     needs: check-formatting
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: "MacOS x86"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
  "num_cpus",
  "path-slash",
  "predicates",
+ "regex",
  "rstest",
  "serde",
  "structopt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ toml = "0.7"
 num_cpus = "1.15"
 fs_extra = "1.2"
 path-slash = "0.2"
+regex = "1.10"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -69,7 +69,8 @@ pub fn build(
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,
-            )),
+            ))
+            .args(crate::platforms::shared::macos_build_opts_ignore_dupicate_libs_warnings()),
         "LLVM building cmake",
     )?;
 

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -3,10 +3,9 @@
 //!
 
 /// The build options shared by all platforms.
-pub const SHARED_BUILD_OPTS: [&str; 18] = [
+pub const SHARED_BUILD_OPTS: [&str; 17] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
-    "-DCLANG_VENDOR='Matter Labs'",
-    "-DCLANG_REPOSITORY_STRING='origin'",
+    "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
     "-DCMAKE_COLOR_DIAGNOSTICS='Off'",
     "-DLLVM_BUILD_DOCS='Off'",
     "-DLLVM_INCLUDE_DOCS='Off'",
@@ -33,7 +32,9 @@ pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 5] = [
     "-DLLVM_INCLUDE_RUNTIMES='Off'",
 ];
 
+///
 /// The build options to enable assertions.
+///
 pub fn shared_build_opts_assertions(enabled: bool) -> Vec<String> {
     vec![format!(
         "-DLLVM_ENABLE_ASSERTIONS='{}'",
@@ -41,7 +42,9 @@ pub fn shared_build_opts_assertions(enabled: bool) -> Vec<String> {
     )]
 }
 
+///
 /// The LLVM tests build options shared by all platforms.
+///
 pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {
     vec![
         format!(
@@ -63,7 +66,9 @@ pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {
     ]
 }
 
+///
 /// The code coverage build options shared by all platforms.
+///
 pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
     vec![format!(
         "-DLLVM_BUILD_INSTRUMENTED_COVERAGE='{}'",
@@ -71,12 +76,30 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
     )]
 }
 
-/// Use of compiler cache (ccache) to speed up the build process
+///
+/// Use of compiler cache (ccache) to speed up the build process.
+///
 pub fn shared_build_opts_ccache(use_ccache: bool) -> Vec<String> {
     if use_ccache {
         vec![
             "-DCMAKE_C_COMPILER_LAUNCHER='ccache'".to_owned(),
             "-DCMAKE_CXX_COMPILER_LAUNCHER='ccache'".to_owned(),
+        ]
+    } else {
+        vec![]
+    }
+}
+
+///
+/// Ignore duplicate libraries warnings for MacOS with XCode>=15.
+///
+pub fn macos_build_opts_ignore_dupicate_libs_warnings() -> Vec<String> {
+    let xcode_version =
+        crate::utils::get_xcode_version().unwrap_or(crate::utils::XCODE_MIN_VERSION);
+    if xcode_version >= crate::utils::XCODE_VERSION_15 {
+        vec![
+            "-DCMAKE_EXE_LINKER_FLAGS='-Wl,-no_warn_duplicate_libraries'".to_owned(),
+            "-DCMAKE_SHARED_LINKER_FLAGS='-Wl,-no_warn_duplicate_libraries'".to_owned(),
         ]
     } else {
         vec![]

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -69,7 +69,8 @@ pub fn build(
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,
-            )),
+            ))
+            .args(crate::platforms::shared::macos_build_opts_ignore_dupicate_libs_warnings()),
         "LLVM building cmake",
     )?;
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -4,7 +4,7 @@ pub const ZKEVM_LLVM: &str = "zkevm-llvm";
 pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const ERA_LLVM_REPO_URL: &str = "https://github.com/matter-labs/era-compiler-llvm";
 pub const ERA_LLVM_REPO_TEST_BRANCH: &str = "v1.4.2";
-pub const ERA_LLVM_REPO_TEST_REF: &str = "714cc6aa05ea03dab3e4e504cb8c25973a33ea94";
+pub const ERA_LLVM_REPO_TEST_REF: &str = "b5ccf6d5774e9bc3cee47ab4a334404718d3adfd";
 pub const ERA_LLVM_REPO_TEST_SHA_INVALID: &str = "12345abcd";
 pub const LLVM_LOCK_FILE: &str = "LLVM.lock";
 


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Disable duplicate library warnings on XCode >= 15.

## Why ❔

To have clean output logs.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
