### PR TITLE
feat: separate musl from targets, native downloader and ci update 

### DIFF
--- a/.github/actions/build_and_test/action.yml
+++ b/.github/actions/build_and_test/action.yml
@@ -5,9 +5,12 @@ runs:
   steps:
     - name: Build and test
       shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      env:
+        LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
       run: |
         cargo install cargo2junit
-        cargo test --no-fail-fast -- -Z unstable-options --format json \
+        [ "${RUNNER_OS}" = "Windows" ] && ADD_FLAGS="--skip debug_build_with_tests_coverage"
+        cargo test --no-fail-fast -- ${ADD_FLAGS} -Z unstable-options --format json \
           | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
 
     - name: Upload test results (Linux)

--- a/.github/actions/build_and_test/action.yml
+++ b/.github/actions/build_and_test/action.yml
@@ -1,0 +1,35 @@
+name: 'Build and test'
+description: 'Builds and tests LLVM builder.'
+runs:
+  using: "composite"
+  steps:
+    - name: Build and test
+      shell: ${{ runner.os == 'Windows' && 'msys2 {0}' || 'bash' }}
+      run: |
+        cargo install cargo2junit
+        cargo test --no-fail-fast -- -Z unstable-options --format json \
+          | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+
+    - name: Upload test results (Linux)
+      if: runner.os == 'Linux'
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      with:
+        check_name: ${{ matrix.name }} Test Results
+        files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+        action_fail_on_inconclusive: true
+
+    - name: Upload test results (MacOS)
+      if: runner.os == 'macos'
+      uses: EnricoMi/publish-unit-test-result-action/macos@v2
+      with:
+        check_name: ${{ matrix.name }} Test Results
+        files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+        action_fail_on_inconclusive: true
+
+    - name: Upload test results (windows)
+      if: runner.os == 'Windows'
+      uses: EnricoMi/publish-unit-test-result-action/windows@v2
+      with:
+        check_name: ${{ matrix.name }} Test Results
+        files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+        action_fail_on_inconclusive: true

--- a/.github/actions/prepare-msys/action.yml
+++ b/.github/actions/prepare-msys/action.yml
@@ -1,0 +1,30 @@
+name: 'Install msys2'
+description: 'Prepares msys2 for Windows builds.'
+runs:
+  using: composite
+  steps:
+    - name: Setup msys2
+      uses: msys2/setup-msys2@v2
+      with:
+        path-type: inherit # Important to correctly update PATH
+
+    - name: Prepare env
+      shell: 'msys2 {0}'
+      env:
+        MINGW64_DOWNLOAD_URL: "https://repo.msys2.org/mingw/mingw64"
+        MINGW64_DOWNLOAD_FILENAME: "mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst"
+      run: |
+        pacman-key --refresh
+        pacman -Sy
+        curl -LO "$MINGW64_DOWNLOAD_URL/$MINGW64_DOWNLOAD_FILENAME"
+        pacman --noconfirm -U "$MINGW64_DOWNLOAD_FILENAME"
+        pacman --noconfirm -S --needed --overwrite \
+          base-devel \
+          git \
+          ninja \
+          mingw-w64-x86_64-clang \
+          mingw-w64-x86_64-lld \
+          mingw-w64-x86_64-rust \
+          mingw-w64-x86_64-gcc-libs \
+          mingw-w64-x86_64-gcc
+        echo "/c/Users/runneradmin/.cargo/bin" >> "${GITHUB_PATH}"

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -30,90 +30,90 @@ jobs:
       - name: Run clippy
         run: cargo clippy
 
-  build-and-test-windows:
-    needs: check-formatting
-    name: "Windows"
-    runs-on: windows-2022-github-hosted-16core
-    env:
-      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-    defaults:
-      run:
-        shell: msys2 {0}
-    steps:
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare msys2
-        uses: msys2/setup-msys2@v2
-      - name: Prepare env
-        run: |
-          pacman-key --refresh
-          pacman -Sy
-          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-          pacman --noconfirm -S --needed --overwrite \
-          base-devel \
-          git \
-          ninja \
-          mingw-w64-x86_64-clang \
-          mingw-w64-x86_64-lld \
-          mingw-w64-x86_64-rust \
-          mingw-w64-x86_64-gcc-libs \
-          mingw-w64-x86_64-gcc
-      - name: Build
-        run: |
-          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-          cargo build --release
-      - name: Test
-        run: |
-          export PATH="$PATH:/c/Users/runneradmin/.cargo/bin/"
-          cargo install cargo2junit
-          cargo test --no-fail-fast -- --skip debug_build_with_tests_coverage -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
-        with:
-          check_name: Windows Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
-
-  build-and-test-macos:
-    needs: check-formatting
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: "MacOS x86"
-            runner: macos-12-large
-          - name: "MacOS arm64"
-            runner: [ self-hosted, macOS, ARM64 ]
-    runs-on: ${{ matrix.runner }}
-    name: ${{ matrix.name }}
-    steps:
-      - name: Cleanup workspace
-        if: matrix.name == 'MacOS arm64'
-        run: |
-          rm -rf ${{ github.workspace }}/*
-          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
-          echo "/opt/homebrew/bin" >> $GITHUB_PATH
-      - name: Checkout source
-        uses: actions/checkout@v4
-      - name: Prepare environment
-        run: brew install cmake ninja
-      - name: Build
-        run: cargo build --release
-      - name: Test
-        run: |
-          cargo install cargo2junit
-          cargo test --no-fail-fast -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+#  build-and-test-windows:
+#    needs: check-formatting
+#    name: "Windows"
+#    runs-on: windows-2022-github-hosted-16core
+#    env:
+#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
+#    defaults:
+#      run:
+#        shell: msys2 {0}
+#    steps:
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare msys2
+#        uses: msys2/setup-msys2@v2
+#      - name: Prepare env
+#        run: |
+#          pacman-key --refresh
+#          pacman -Sy
+#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
+#          pacman --noconfirm -S --needed --overwrite \
+#          base-devel \
+#          git \
+#          ninja \
+#          mingw-w64-x86_64-clang \
+#          mingw-w64-x86_64-lld \
+#          mingw-w64-x86_64-rust \
+#          mingw-w64-x86_64-gcc-libs \
+#          mingw-w64-x86_64-gcc
+#      - name: Build
+#        run: |
+#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
+#          cargo build --release
+#      - name: Test
+#        run: |
+#          export PATH="$PATH:/c/Users/runneradmin/.cargo/bin/"
+#          cargo install cargo2junit
+#          cargo test --no-fail-fast -- --skip debug_build_with_tests_coverage -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
+#        with:
+#          check_name: Windows Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
+#
+#  build-and-test-macos:
+#    needs: check-formatting
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        include:
+#          - name: "MacOS x86"
+#            runner: macos-12-large
+#          - name: "MacOS arm64"
+#            runner: [ self-hosted, macOS, ARM64 ]
+#    runs-on: ${{ matrix.runner }}
+#    name: ${{ matrix.name }}
+#    steps:
+#      - name: Cleanup workspace
+#        if: matrix.name == 'MacOS arm64'
+#        run: |
+#          rm -rf ${{ github.workspace }}/*
+#          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+#          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+#      - name: Checkout source
+#        uses: actions/checkout@v4
+#      - name: Prepare environment
+#        run: brew install cmake ninja
+#      - name: Build
+#        run: cargo build --release
+#      - name: Test
+#        run: |
+#          cargo install cargo2junit
+#          cargo test --no-fail-fast -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+#      - name: Upload test results
+#        if: always()
+#        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
+#        with:
+#          check_name: ${{ matrix.name }} Unit Tests Results
+#          github_token: ${{ secrets.GITHUB_TOKEN }}
+#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
+#          action_fail_on_inconclusive: true
 
   build-and-test-linux:
     needs: check-formatting
@@ -121,19 +121,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Linux x86_64 gnu"
+          - name: "Linux x86_64"
             runner: matterlabs-ci-runner
-            target: "x86_64-unknown-linux-gnu"
-          - name: "Linux aarch64 gnu"
+          - name: "Linux aarch64"
             runner: matterlabs-ci-runner-arm
-            target: "aarch64-unknown-linux-gnu"
-          - name: "Linux x86_64 musl"
-            runner: matterlabs-ci-runner
-            target: "x86_64-unknown-linux-musl"
-          - name: "Linux arm64 musl"
-            runner: matterlabs-ci-runner-arm
-            target: "aarch64-unknown-linux-musl"
-            rustflags: "-C link-arg=-Wl,-Bstatic -C link-arg=-lc -C link-arg=-L/usr/lib/llvm-17/lib/clang/17/lib/linux/ -C link-arg=-lclang_rt.builtins-aarch64"
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     container:
@@ -144,21 +135,14 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Build
-        run: |
-          rustup target add ${{ matrix.target }}
-          cargo build --release
-
-      - name: Test
+      - name: Build and test
         uses: nick-fields/retry@v2
         with:
           timeout_minutes: 120
           max_attempts: 2 # protection mechanism for sporadic dependencies download failure
           command: |
             cargo install cargo2junit
-            # Disable unsupported tests
-            [[ ${{ matrix.target }} != *musl* ]] && INCLUDE_IGNORED="--include-ignored"
-            cargo test --target ${{ matrix.target }} --no-fail-fast -- -Z unstable-options --format json ${INCLUDE_IGNORED} \
+            cargo test --no-fail-fast -- -Z unstable-options --format json ${INCLUDE_IGNORED} \
               | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
 
       - name: Upload test results

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -30,126 +30,38 @@ jobs:
       - name: Run clippy
         run: cargo clippy
 
-#  build-and-test-windows:
-#    needs: check-formatting
-#    name: "Windows"
-#    runs-on: windows-2022-github-hosted-16core
-#    env:
-#      LIBSTDCPP_SOURCE_PATH: "C:/a/_temp/msys64/mingw64/lib/libstdc++.a"
-#    defaults:
-#      run:
-#        shell: msys2 {0}
-#    steps:
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare msys2
-#        uses: msys2/setup-msys2@v2
-#      - name: Prepare env
-#        run: |
-#          pacman-key --refresh
-#          pacman -Sy
-#          curl -LO https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -U mingw-w64-x86_64-cmake-3.27.7-3-any.pkg.tar.zst
-#          pacman --noconfirm -S --needed --overwrite \
-#          base-devel \
-#          git \
-#          ninja \
-#          mingw-w64-x86_64-clang \
-#          mingw-w64-x86_64-lld \
-#          mingw-w64-x86_64-rust \
-#          mingw-w64-x86_64-gcc-libs \
-#          mingw-w64-x86_64-gcc
-#      - name: Build
-#        run: |
-#          export PATH="${PATH}:/c/Users/runneradmin/.cargo/bin/"
-#          cargo build --release
-#      - name: Test
-#        run: |
-#          export PATH="$PATH:/c/Users/runneradmin/.cargo/bin/"
-#          cargo install cargo2junit
-#          cargo test --no-fail-fast -- --skip debug_build_with_tests_coverage -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
-#        with:
-#          check_name: Windows Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
-#
-#  build-and-test-macos:
-#    needs: check-formatting
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        include:
-#          - name: "MacOS x86"
-#            runner: macos-12-large
-#          - name: "MacOS arm64"
-#            runner: [ self-hosted, macOS, ARM64 ]
-#    runs-on: ${{ matrix.runner }}
-#    name: ${{ matrix.name }}
-#    steps:
-#      - name: Cleanup workspace
-#        if: matrix.name == 'MacOS arm64'
-#        run: |
-#          rm -rf ${{ github.workspace }}/*
-#          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
-#          echo "/opt/homebrew/bin" >> $GITHUB_PATH
-#      - name: Checkout source
-#        uses: actions/checkout@v4
-#      - name: Prepare environment
-#        run: brew install cmake ninja
-#      - name: Build
-#        run: cargo build --release
-#      - name: Test
-#        run: |
-#          cargo install cargo2junit
-#          cargo test --no-fail-fast -- -Z unstable-options --format json | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
-#      - name: Upload test results
-#        if: always()
-#        uses: EnricoMi/publish-unit-test-result-action/composite@v2.12.0
-#        with:
-#          check_name: ${{ matrix.name }} Unit Tests Results
-#          github_token: ${{ secrets.GITHUB_TOKEN }}
-#          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-#          action_fail_on_inconclusive: true
-
-  build-and-test-linux:
+  build-and-test:
     needs: check-formatting
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: "Linux x86_64"
+            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
             runner: matterlabs-ci-runner
           - name: "Linux aarch64"
+            image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
             runner: matterlabs-ci-runner-arm
+          - name: "MacOS x86"
+            runner: macos-12-large
+          - name: "Windows"
+            runner: windows-2022-github-hosted-16core
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.name }}
     container:
-      image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
-    env:
-      RUSTFLAGS: ${{ matrix.rustflags }}
+      image: ${{ matrix.image || '' }}
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
 
-      - name: Build and test
-        uses: nick-fields/retry@v2
-        with:
-          timeout_minutes: 120
-          max_attempts: 2 # protection mechanism for sporadic dependencies download failure
-          command: |
-            cargo install cargo2junit
-            cargo test --no-fail-fast -- -Z unstable-options --format json ${INCLUDE_IGNORED} \
-              | cargo2junit | tee "${UNIT_TESTS_RESULTS_XML}"
+      - name: Prepare Windows env
+        if: runner.os == 'Windows'
+        uses: ./.github/actions/prepare-msys
 
-      - name: Upload test results
-        if: always()
-        uses: EnricoMi/publish-unit-test-result-action@v2.12.0
-        with:
-          check_name: ${{ matrix.name }} Unit Tests Results
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ env.UNIT_TESTS_RESULTS_XML }}
-          action_fail_on_inconclusive: true
+      - name: Prepare MacOS environment
+        shell: bash
+        if: runner.os == 'macOS'
+        run: brew install cmake ninja
+
+      - name: Build and test
+        uses: ./.github/actions/build_and_test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,6 +75,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
+name = "backtrace"
+version = "0.3.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +117,24 @@ dependencies = [
  "regex-automata",
  "serde",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "bytes"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
+
+[[package]]
+name = "cc"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 
 [[package]]
 name = "cfg-if"
@@ -106,7 +160,10 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "assert_fs",
+ "downloader",
+ "flate2",
  "fs_extra",
+ "http",
  "num_cpus",
  "path-slash",
  "predicates",
@@ -114,7 +171,33 @@ dependencies = [
  "rstest",
  "serde",
  "structopt",
+ "tar",
  "toml",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -155,6 +238,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
+name = "downloader"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05213e96f184578b5f70105d4d0a644a168e99e12d7bea0b200c15d67b5c182"
+dependencies = [
+ "futures",
+ "rand",
+ "reqwest",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,7 +272,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -177,12 +282,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
+name = "filetime"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ee447700ac8aa0b2f2bd7bc4462ad686ba06baa6727ac149a2d6277f0d240fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "float-cmp"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
 ]
 
 [[package]]
@@ -287,6 +444,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "gimli"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +491,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +529,87 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "idna"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
 
 [[package]]
 name = "ignore"
@@ -361,6 +635,27 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -394,6 +689,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -419,10 +758,75 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.32.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "openssl"
+version = "0.10.64"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+dependencies = [
+ "bitflags 2.5.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "path-slash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
@@ -435,6 +839,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "predicates"
@@ -509,6 +925,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +999,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "rstest"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,6 +1068,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,8 +1092,23 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
 
 [[package]]
 name = "same-file"
@@ -601,6 +1117,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbc91545643bcf3a0bbb6569265615222618bdf33ce4ffbbd13c4bbd4c093534"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -630,11 +1178,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.116"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
  "serde",
 ]
 
@@ -645,6 +1216,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -694,6 +1275,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,7 +1321,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "rustix",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -718,6 +1337,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -755,10 +1449,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -771,6 +1511,23 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "url"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -795,6 +1552,97 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "web-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -830,11 +1678,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -843,15 +1715,21 @@ version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f0713a46559409d202e70e28227288446bf7841d3211583a4b53e3f6d96e7eb"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.5",
+ "windows_aarch64_msvc 0.52.5",
+ "windows_i686_gnu 0.52.5",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.5",
+ "windows_x86_64_gnu 0.52.5",
+ "windows_x86_64_gnullvm 0.52.5",
+ "windows_x86_64_msvc 0.52.5",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -861,9 +1739,21 @@ checksum = "7088eed71e8b8dda258ecc8bac5fb1153c5cffaf2578fc8ff5d61e23578d3263"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9985fd1504e250c615ca5f281c3f7a6da76213ebd5ccc9561496568a2752afb6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -879,9 +1769,21 @@ checksum = "87f4261229030a858f36b459e748ae97545d6f1ec60e5e0d6a3d32e0dc232ee9"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db3c2bf3d13d5b658be73463284eaf12830ac9a26a90c717b7f771dfe97487bf"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -891,9 +1793,21 @@ checksum = "4e4246f76bdeff09eb48875a0fd3e2af6aada79d409d33011886d3e1581517d9"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "852298e482cd67c356ddd9570386e2862b5673c85bd5f88df9ab6802b334c596"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -908,4 +1822,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "xattr"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.22"
+version = "1.0.23"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,10 @@ num_cpus = "1.15"
 fs_extra = "1.2"
 path-slash = "0.2"
 regex = "1.10"
+downloader = "0.2"
+tar = "0.4"
+flate2 = "1.0"
+http = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.22"
+version = "1.0.23"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,11 @@ pub fn clone_host() -> anyhow::Result<()> {
 ///
 /// Executes the LLVM repository cloning.
 ///
-pub fn clone(lock: Lock, deep: bool) -> anyhow::Result<()> {
+pub fn clone(lock: Lock, deep: bool, use_musl: bool) -> anyhow::Result<()> {
     utils::check_presence("git")?;
 
     // Clone the host repository if the target is musl.
-    if cfg!(target_os = "linux") && cfg!(target_env = "musl") {
+    if cfg!(target_os = "linux") && use_musl {
         clone_host()?;
     }
 
@@ -140,8 +140,10 @@ pub fn checkout(lock: Lock, force: bool) -> anyhow::Result<()> {
 /// argument is not possible. So for cross-platform testing, comment out all but the
 /// line to be tested, and perhaps also checks in the platform-specific build method.
 ///
+#[allow(clippy::too_many_arguments)]
 pub fn build(
     build_type: BuildType,
+    use_musl: bool,
     targets: HashSet<Platform>,
     enable_tests: bool,
     enable_coverage: bool,
@@ -153,17 +155,7 @@ pub fn build(
 
     if cfg!(target_arch = "x86_64") {
         if cfg!(target_os = "linux") {
-            if cfg!(target_env = "gnu") {
-                platforms::x86_64_linux_gnu::build(
-                    build_type,
-                    targets,
-                    enable_tests,
-                    enable_coverage,
-                    extra_args,
-                    use_ccache,
-                    enable_assertions,
-                )?;
-            } else if cfg!(target_env = "musl") {
+            if use_musl {
                 platforms::x86_64_linux_musl::build(
                     build_type,
                     targets,
@@ -174,7 +166,15 @@ pub fn build(
                     enable_assertions,
                 )?;
             } else {
-                anyhow::bail!("Unsupported target environment for x86_64 and Linux");
+                platforms::x86_64_linux_gnu::build(
+                    build_type,
+                    targets,
+                    enable_tests,
+                    enable_coverage,
+                    extra_args,
+                    use_ccache,
+                    enable_assertions,
+                )?;
             }
         } else if cfg!(target_os = "macos") {
             platforms::x86_64_macos::build(
@@ -201,17 +201,7 @@ pub fn build(
         }
     } else if cfg!(target_arch = "aarch64") {
         if cfg!(target_os = "linux") {
-            if cfg!(target_env = "gnu") {
-                platforms::aarch64_linux_gnu::build(
-                    build_type,
-                    targets,
-                    enable_tests,
-                    enable_coverage,
-                    extra_args,
-                    use_ccache,
-                    enable_assertions,
-                )?;
-            } else if cfg!(target_env = "musl") {
+            if use_musl {
                 platforms::aarch64_linux_musl::build(
                     build_type,
                     targets,
@@ -222,7 +212,15 @@ pub fn build(
                     enable_assertions,
                 )?;
             } else {
-                anyhow::bail!("Unsupported target environment for aarch64 and Linux");
+                platforms::aarch64_linux_gnu::build(
+                    build_type,
+                    targets,
+                    enable_tests,
+                    enable_coverage,
+                    extra_args,
+                    use_ccache,
+                    enable_assertions,
+                )?;
             }
         } else if cfg!(target_os = "macos") {
             platforms::aarch64_macos::build(

--- a/src/llvm_path.rs
+++ b/src/llvm_path.rs
@@ -38,6 +38,15 @@ impl LLVMPath {
     }
 
     ///
+    /// Returns the path to the MUSL source.
+    ///
+    pub fn musl_source(name: &str) -> anyhow::Result<PathBuf> {
+        let mut path = PathBuf::from(Self::DIRECTORY_LLVM_TARGET);
+        path.push(name);
+        crate::utils::absolute_path(path)
+    }
+
+    ///
     /// Returns the path to the MUSL build directory.
     ///
     pub fn musl_build(source_directory: &str) -> anyhow::Result<PathBuf> {

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -28,6 +28,29 @@ pub enum Platform {
     EVM,
 }
 
+///
+/// The list of target environments used as constants.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TargetEnv {
+    /// The GNU target environment.
+    GNU,
+    /// The MUSL target environment.
+    MUSL,
+}
+
+impl FromStr for TargetEnv {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "gnu" => Ok(Self::GNU),
+            "musl" => Ok(Self::MUSL),
+            value => Err(format!("Unsupported target environment: `{}`", value)),
+        }
+    }
+}
+
 impl FromStr for Platform {
     type Err = String;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,6 +2,7 @@
 //! The LLVM builder utilities.
 //!
 
+use std::env;
 use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
@@ -14,12 +15,6 @@ use flate2::read::GzDecoder;
 use path_slash::PathBufExt;
 use regex::Regex;
 use tar::Archive;
-
-/// The dry run flag.
-pub const DRY_RUN: bool = false;
-
-/// Enable verbose output.
-pub const VERBOSE: bool = false;
 
 /// The LLVM host repository URL.
 pub const LLVM_HOST_SOURCE_URL: &str = "https://github.com/llvm/llvm-project";
@@ -51,10 +46,10 @@ pub const MUSL_SNAPSHOTS_URL: &str = "https://git.musl-libc.org/cgit/musl/snapsh
 /// Checks the status and prints `stderr`.
 ///
 pub fn command(command: &mut Command, description: &str) -> anyhow::Result<()> {
-    if VERBOSE {
+    if env::var("VERBOSE").is_ok() {
         println!("\ndescription: {}; command: {:?}", description, command);
     }
-    if DRY_RUN {
+    if env::var("DRY_RUN").is_ok() {
         println!("\tOnly a dry run; not executing the command.");
     } else {
         let status = command

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,13 +2,18 @@
 //! The LLVM builder utilities.
 //!
 
+use std::fs::File;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Stdio;
+use std::time::Duration;
 
+use downloader::Downloader;
+use flate2::read::GzDecoder;
 use path_slash::PathBufExt;
 use regex::Regex;
+use tar::Archive;
 
 /// The dry run flag.
 pub const DRY_RUN: bool = false;
@@ -27,6 +32,18 @@ pub const XCODE_MIN_VERSION: u32 = 11;
 
 /// The XCode version 15.
 pub const XCODE_VERSION_15: u32 = 15;
+
+/// The number of download retries if failed.
+pub const DOWNLOAD_RETRIES: u16 = 3;
+
+/// The number of parallel download requests.
+pub const DOWNLOAD_PARALLEL_REQUESTS: u16 = 1;
+
+/// The download timeout in seconds.
+pub const DOWNLOAD_TIMEOUT_SECONDS: u64 = 300;
+
+/// The musl snapshots URL.
+pub const MUSL_SNAPSHOTS_URL: &str = "https://git.musl-libc.org/cgit/musl/snapshot";
 
 ///
 /// The subprocess runner.
@@ -47,6 +64,125 @@ pub fn command(command: &mut Command, description: &str) -> anyhow::Result<()> {
             anyhow::bail!("{} failed", description);
         }
     }
+    Ok(())
+}
+
+///
+/// Download a file from the URL to the path.
+///
+pub fn download(url: &str, path: &str) -> anyhow::Result<()> {
+    let mut downloader = Downloader::builder()
+        .download_folder(Path::new(path))
+        .parallel_requests(DOWNLOAD_PARALLEL_REQUESTS)
+        .retries(DOWNLOAD_RETRIES)
+        .timeout(Duration::from_secs(DOWNLOAD_TIMEOUT_SECONDS))
+        .build()?;
+    let dl = downloader::Download::new(url);
+    for r in downloader.download(&[dl])? {
+        let summary = r.map_err(|error| anyhow::anyhow!("{}", error))?;
+        for download_result in summary.status {
+            let url = download_result.0;
+            let http_result = download_result.1;
+            if http_result != http::status::StatusCode::OK {
+                anyhow::bail!("{url} failed with HTTP code: {http_result}");
+            }
+        }
+    }
+    Ok(())
+}
+
+///
+/// Unpack a tarball.
+///
+pub fn unpack_tar(filename: PathBuf, path: &str) -> anyhow::Result<()> {
+    let tar_gz = File::open(filename)?;
+    let tar = GzDecoder::new(tar_gz);
+    let mut archive = Archive::new(tar);
+    archive.unpack(path)?;
+    Ok(())
+}
+
+///
+/// The `musl` downloading sequence.
+///
+pub fn download_musl(name: &str) -> anyhow::Result<()> {
+    let tar_file_name = format!("{name}.tar.gz");
+    let url = format!("{}/{tar_file_name}", MUSL_SNAPSHOTS_URL);
+    download(url.as_str(), crate::LLVMPath::DIRECTORY_LLVM_TARGET)?;
+    let musl_tarball = crate::LLVMPath::musl_source(tar_file_name.as_str())?;
+    unpack_tar(musl_tarball, crate::LLVMPath::DIRECTORY_LLVM_TARGET)?;
+    Ok(())
+}
+
+///
+/// The `musl` building sequence.
+///
+pub fn build_musl(build_directory: &Path, target_directory: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(build_directory)?;
+    std::fs::create_dir_all(target_directory)?;
+
+    command(
+        Command::new("../configure")
+            .current_dir(build_directory)
+            .arg(format!("--prefix={}", target_directory.to_string_lossy()))
+            .arg(format!(
+                "--syslibdir={}/lib/",
+                target_directory.to_string_lossy()
+            ))
+            .arg("--enable-wrapper='clang'"),
+        "MUSL configuring",
+    )?;
+    command(
+        Command::new("make")
+            .current_dir(build_directory)
+            .arg("-j")
+            .arg(num_cpus::get().to_string()),
+        "MUSL building",
+    )?;
+    command(
+        Command::new("make")
+            .current_dir(build_directory)
+            .arg("install"),
+        "MUSL installing",
+    )?;
+
+    let mut include_directory = target_directory.to_path_buf();
+    include_directory.push("include/");
+
+    let mut asm_include_directory = include_directory.clone();
+    asm_include_directory.push("asm/");
+    std::fs::create_dir_all(asm_include_directory.as_path())?;
+
+    let mut types_header_path = asm_include_directory.clone();
+    types_header_path.push("types.h");
+
+    let copy_options = fs_extra::dir::CopyOptions {
+        overwrite: true,
+        copy_inside: true,
+        ..Default::default()
+    };
+    fs_extra::dir::copy("/usr/include/linux", include_directory, &copy_options)?;
+
+    let copy_options = fs_extra::dir::CopyOptions {
+        overwrite: true,
+        copy_inside: true,
+        content_only: true,
+        ..Default::default()
+    };
+    fs_extra::dir::copy(
+        "/usr/include/asm-generic",
+        asm_include_directory,
+        &copy_options,
+    )?;
+
+    command(
+        Command::new("sed")
+            .arg("-i")
+            .arg("s/asm-generic/asm/")
+            .arg(types_header_path),
+        "types_header asm signature replacement",
+    )?;
+
     Ok(())
 }
 

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -15,18 +15,18 @@ pub enum Arguments {
         /// Clone with full commits history.
         #[structopt(long)]
         deep: bool,
-        /// Build LLVM with musl.
-        #[structopt(long = "musl")]
-        use_musl: bool,
+        /// Target environment to build LLVM (GNU or MUSL).
+        #[structopt(long = "target-env", default_value = "gnu")]
+        target_env: compiler_llvm_builder::platforms::TargetEnv,
     },
     /// Build the LLVM framework.
     Build {
         /// Whether to build the 'Debug' version.
         #[structopt(long = "debug")]
         debug: bool,
-        /// Build LLVM with musl.
-        #[structopt(long = "musl")]
-        use_musl: bool,
+        /// Target environment to build LLVM (`gnu` or `musl`).
+        #[structopt(long = "target-env", default_value = "gnu")]
+        target_env: compiler_llvm_builder::platforms::TargetEnv,
         /// Additional targets to build LLVM with.
         #[structopt(long = "targets", multiple = true)]
         targets: Vec<String>,

--- a/src/zkevm_llvm/arguments.rs
+++ b/src/zkevm_llvm/arguments.rs
@@ -15,12 +15,18 @@ pub enum Arguments {
         /// Clone with full commits history.
         #[structopt(long)]
         deep: bool,
+        /// Build LLVM with musl.
+        #[structopt(long = "musl")]
+        use_musl: bool,
     },
     /// Build the LLVM framework.
     Build {
         /// Whether to build the 'Debug' version.
         #[structopt(long = "debug")]
         debug: bool,
+        /// Build LLVM with musl.
+        #[structopt(long = "musl")]
+        use_musl: bool,
         /// Additional targets to build LLVM with.
         #[structopt(long = "targets", multiple = true)]
         targets: Vec<String>,

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -42,12 +42,13 @@ fn main_inner() -> anyhow::Result<()> {
     let arguments = Arguments::new();
 
     match arguments {
-        Arguments::Clone { deep } => {
+        Arguments::Clone { deep, use_musl } => {
             let lock = compiler_llvm_builder::Lock::try_from(&PathBuf::from("LLVM.lock"))?;
-            compiler_llvm_builder::clone(lock, deep)?;
+            compiler_llvm_builder::clone(lock, deep, use_musl)?;
         }
         Arguments::Build {
             debug,
+            use_musl,
             targets,
             enable_tests,
             enable_coverage,
@@ -85,6 +86,7 @@ fn main_inner() -> anyhow::Result<()> {
 
             compiler_llvm_builder::build(
                 build_type,
+                use_musl,
                 targets,
                 enable_tests,
                 enable_coverage,

--- a/src/zkevm_llvm/main.rs
+++ b/src/zkevm_llvm/main.rs
@@ -5,6 +5,7 @@
 pub(crate) mod arguments;
 
 use std::collections::HashSet;
+use std::env;
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -32,7 +33,7 @@ fn main() {
 /// The entry result wrapper.
 ///
 fn main_inner() -> anyhow::Result<()> {
-    if compiler_llvm_builder::utils::VERBOSE {
+    if env::var("VERBOSE").is_ok() {
         println!("std::env::args(): {:#?}", std::env::args());
         println!(
             "\nstd::env::args() collected: {}",
@@ -42,13 +43,13 @@ fn main_inner() -> anyhow::Result<()> {
     let arguments = Arguments::new();
 
     match arguments {
-        Arguments::Clone { deep, use_musl } => {
+        Arguments::Clone { deep, target_env } => {
             let lock = compiler_llvm_builder::Lock::try_from(&PathBuf::from("LLVM.lock"))?;
-            compiler_llvm_builder::clone(lock, deep, use_musl)?;
+            compiler_llvm_builder::clone(lock, deep, target_env)?;
         }
         Arguments::Build {
             debug,
-            use_musl,
+            target_env,
             targets,
             enable_tests,
             enable_coverage,
@@ -75,7 +76,7 @@ fn main_inner() -> anyhow::Result<()> {
                         .to_owned()
                 })
                 .collect();
-            if compiler_llvm_builder::utils::VERBOSE {
+            if env::var("VERBOSE").is_ok() {
                 println!("\nextra_args: {:#?}", extra_args);
                 println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
             }
@@ -86,7 +87,7 @@ fn main_inner() -> anyhow::Result<()> {
 
             compiler_llvm_builder::build(
                 build_type,
-                use_musl,
+                target_env,
                 targets,
                 enable_tests,
                 enable_coverage,

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -72,6 +72,47 @@ fn clone_build_and_clean() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Tests the clone, build, and clean process of the LLVM repository for MUSL target.
+///
+/// This test verifies that the LLVM repository can be successfully cloned, built, and cleaned
+/// with 2-staged build using MUSL as sysroot.
+///
+/// # Errors
+///
+/// Returns an error if any of the test assertions fail or if there is an error while executing
+/// the build or clean commands.
+///
+/// # Returns
+///
+/// Returns `Ok(())` if the test passes.
+#[rstest]
+#[timeout(std::time::Duration::from_secs(5000))]
+fn clone_build_and_clean_musl() -> anyhow::Result<()> {
+    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let test_dir = lockfile
+        .parent()
+        .expect("Lockfile parent dir does not exist");
+    cmd.current_dir(test_dir);
+    cmd.arg("clone").arg("--musl");
+    cmd.assert()
+        .success()
+        .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
+    let mut build_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    build_cmd.current_dir(test_dir);
+    build_cmd
+        .arg("build")
+        .arg("--musl")
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("Installing:.*").unwrap());
+    let mut clean_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    clean_cmd.current_dir(test_dir);
+    clean_cmd.arg("clean");
+    clean_cmd.assert().success();
+    Ok(())
+}
+
 /// Tests the debug build process of the LLVM repository with tests and coverage enabled.
 ///
 /// This test verifies that the LLVM repository can be successfully cloned and built in debug mode
@@ -87,7 +128,6 @@ fn clone_build_and_clean() -> anyhow::Result<()> {
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 #[timeout(std::time::Duration::from_secs(5000))]
-#[ignore] // Unsupported for MUSL targets, use --run-ignored to execute for other targets
 fn debug_build_with_tests_coverage() -> anyhow::Result<()> {
     let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
     let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -94,7 +94,7 @@ fn clone_build_and_clean_musl() -> anyhow::Result<()> {
         .parent()
         .expect("Lockfile parent dir does not exist");
     cmd.current_dir(test_dir);
-    cmd.arg("clone").arg("--musl");
+    cmd.arg("clone").arg("--target-env").arg("musl");
     cmd.assert()
         .success()
         .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
@@ -102,7 +102,8 @@ fn clone_build_and_clean_musl() -> anyhow::Result<()> {
     build_cmd.current_dir(test_dir);
     build_cmd
         .arg("build")
-        .arg("--musl")
+        .arg("--target-env")
+        .arg("musl")
         .assert()
         .success()
         .stdout(predicate::str::is_match("Installing:.*").unwrap());


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

* [x] Implement file downloader with retries and timeouts
* [x] Unify CI workflows removing boilerplate using one matrix job instead of 3
* [x] Add `--musl` option for `build` and `clone` allowing building and testing of LLVM Musl targets regardless of the LLVM builder build target
* [x] Make `VERBOSE` and `DRY_RUN` configurable from environment variables

## Why ❔

* To fix sporadic Musl download failures across all workflows
* To ease CI support in the future
* To simplify installation instructions for LLVM builder and allow Musl and Gnu builds with the same standard LLVM builder binaries

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
