### PR TITLE
feat: enable crt builtins for aarch64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.23"
+version = "1.0.24"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
 ]

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -22,8 +22,6 @@ pub fn build(
     use_ccache: bool,
     enable_assertions: bool,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("wget")?;
-    crate::utils::check_presence("tar")?;
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;
@@ -123,6 +121,7 @@ fn build_crt(
                 "-DLLVM_INCLUDE_UTILS='Off'",
                 "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='aarch64'",
                 "-DCOMPILER_RT_BUILD_CRT='On'",
+                "-DCOMPILER_RT_BUILD_BUILTINS='On'",
                 "-DCOMPILER_RT_BUILD_SANITIZERS='Off'",
                 "-DCOMPILER_RT_BUILD_XRAY='Off'",
                 "-DCOMPILER_RT_BUILD_LIBFUZZER='Off'",

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -3,10 +3,9 @@
 //!
 
 /// The build options shared by all platforms.
-pub const SHARED_BUILD_OPTS: [&str; 17] = [
+pub const SHARED_BUILD_OPTS: [&str; 16] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
-    "-DCMAKE_COLOR_DIAGNOSTICS='Off'",
     "-DLLVM_BUILD_DOCS='Off'",
     "-DLLVM_INCLUDE_DOCS='Off'",
     "-DLLVM_INCLUDE_BENCHMARKS='Off'",

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -22,8 +22,6 @@ pub fn build(
     use_ccache: bool,
     enable_assertions: bool,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("wget")?;
-    crate::utils::check_presence("tar")?;
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
     crate::utils::check_presence("clang++")?;


### PR DESCRIPTION
# What ❔

* [x] Enables crt builtins for linux aarch64
* [x] Removes necessity of having `wget` and `tar` installed

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Related to proper fix of [CPR-1581](https://linear.app/matterlabs/issue/CPR-1581/undocumented-additional-zksolczkvyper-cross-compile-build-options).

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
