### PR TITLE
feat!: rename zkevm-llvm to zksync-llvm 

### DIFF
--- a/.github/actions/build_and_test/action.yml
+++ b/.github/actions/build_and_test/action.yml
@@ -20,6 +20,7 @@ runs:
         check_name: ${{ matrix.name }} Test Results
         files: ${{ env.UNIT_TESTS_RESULTS_XML }}
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload test results (MacOS)
       if: runner.os == 'macos'
@@ -28,6 +29,7 @@ runs:
         check_name: ${{ matrix.name }} Test Results
         files: ${{ env.UNIT_TESTS_RESULTS_XML }}
         action_fail_on_inconclusive: true
+        comment_mode: off
 
     - name: Upload test results (windows)
       if: runner.os == 'Windows'
@@ -36,3 +38,4 @@ runs:
         check_name: ${{ matrix.name }} Test Results
         files: ${{ env.UNIT_TESTS_RESULTS_XML }}
         action_fail_on_inconclusive: true
+        comment_mode: off

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.23"
+version = "1.0.25"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.24"
+version = "1.0.25"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
+    "Anton Baliasnikov <aba@matterlabs.dev>",
 ]
 license = "MIT OR Apache-2.0"
 edition = "2021"
-description = "EraVM LLVM Framework Builder"
+description = "ZKsync LLVM Framework Builder"
 repository = "https://github.com/matter-labs/era-compiler-llvm-builder"
 
 [[bin]]
-name = "zkevm-llvm"
-path = "src/zkevm_llvm/main.rs"
+name = "zksync-llvm"
+path = "src/zksync_llvm/main.rs"
 
 [lib]
 doctest = false

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# zkSync Era: LLVM Framework Builder
+# ZKsync Era: LLVM Framework Builder
 
-<p align="center"><a href="https://zksync.io" target="_blank"><img alt="zkSync Era zkEVM is Ethereum’s most user-centric ZK-rollup" title="zkSync Era zkEVM is Ethereum’s most user-centric ZK-rollup" src="https://raw.githubusercontent.com/matter-labs/.github/main/header-image.png" width="100%">
+<p align="center"><a href="https://zksync.io" target="_blank"><img alt="ZKsync Era is Ethereum’s most user-centric ZK-rollup" title="ZKsync Era is Ethereum’s most user-centric ZK-rollup" src="https://raw.githubusercontent.com/matter-labs/.github/main/header-image.png" width="100%">
 </a>
 </p>
 
-zkSync Era is a layer 2 rollup that uses zero-knowledge proofs to scale Ethereum without compromising on security
+ZKsync Era is a layer 2 rollup that uses zero-knowledge proofs to scale Ethereum without compromising on security
 or decentralization. As it's EVM-compatible (with Solidity/Vyper), 99% of Ethereum projects can redeploy without
 needing to refactor or re-audit any code. zkSync Era also uses an LLVM-based compiler that will eventually enable
 developers to write smart contracts in popular languages such as C++ and Rust.
 
-This repository contains the builder of the EraVM fork of the LLVM framework.
+This repository contains the builder of the ZKsync fork of the LLVM framework.
 
 ## License
 
@@ -30,7 +30,7 @@ at your option.
 
 ## Disclaimer
 
-zkSync Era has been through extensive testing and audits, and although it is live, it is still in alpha state and
+ZKsync Era has been through extensive testing and audits, and although it is live, it is still in alpha state and
 will undergo further audits and bug bounty programs. We would love to hear our community's thoughts and suggestions
 about it!
 It's important to note that forking it now could potentially lead to missing important

--- a/src/build_type.rs
+++ b/src/build_type.rs
@@ -1,9 +1,9 @@
 //!
-//! The zkEVM LLVM build type.
+//! The ZKsync LLVM build type.
 //!
 
 ///
-/// The zkEVM LLVM build type.
+/// The ZKsync LLVM build type.
 ///
 #[derive(Debug, PartialEq, Eq)]
 pub enum BuildType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM builder library.
+//! The ZKsync LLVM builder library.
 //!
 
 pub mod build_type;

--- a/src/llvm_path.rs
+++ b/src/llvm_path.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM builder constants.
+//! The ZKsync LLVM builder constants.
 //!
 
 use std::path::PathBuf;

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM builder lock file.
+//! The ZKsync LLVM builder lock file.
 //!
 
 use anyhow::Context;

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM arm64 `linux-gnu` builder.
+//! The ZKsync LLVM arm64 `linux-gnu` builder.
 //!
 
 use std::collections::HashSet;

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM arm64 `linux-musl` builder.
+//! The ZKsync LLVM arm64 `linux-musl` builder.
 //!
 
 use std::collections::HashSet;

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM arm64 `macos-aarch64` builder.
+//! The ZKsync LLVM arm64 `macos-aarch64` builder.
 //!
 
 use std::collections::HashSet;

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM builder platforms.
+//! The ZKsync LLVM builder platforms.
 //!
 
 pub mod aarch64_linux_gnu;

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM amd64 `linux-gnu` builder.
+//! The ZKsync LLVM amd64 `linux-gnu` builder.
 //!
 
 use std::collections::HashSet;

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM amd64 `linux-musl` builder.
+//! The ZKsync LLVM amd64 `linux-musl` builder.
 //!
 
 use std::collections::HashSet;

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM amd64 `macos` builder.
+//! The ZKsync LLVM amd64 `macos` builder.
 //!
 
 use std::collections::HashSet;

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM amd64 `windows-gnu` builder.
+//! The ZKsync LLVM amd64 `windows-gnu` builder.
 //!
 
 use std::collections::HashSet;

--- a/src/zksync_llvm/arguments.rs
+++ b/src/zksync_llvm/arguments.rs
@@ -1,14 +1,14 @@
 //!
-//! The zkEVM LLVM builder arguments.
+//! The ZKsync LLVM builder arguments.
 //!
 
 use structopt::StructOpt;
 
 ///
-/// The zkEVM LLVM builder arguments.
+/// The ZKsync LLVM builder arguments.
 ///
 #[derive(Debug, StructOpt)]
-#[structopt(name = "llvm-builder", about = "The zkEVM LLVM framework builder")]
+#[structopt(name = "llvm-builder", about = "The ZKsync LLVM framework builder")]
 pub enum Arguments {
     /// Clone the branch specified in `LLVM.lock`.
     Clone {

--- a/src/zksync_llvm/main.rs
+++ b/src/zksync_llvm/main.rs
@@ -1,5 +1,5 @@
 //!
-//! The zkEVM LLVM builder.
+//! The ZKsync LLVM builder.
 //!
 
 pub(crate) mod arguments;

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -21,7 +21,7 @@ use rstest::rstest;
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn build_without_clone() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     let file = assert_fs::NamedTempFile::new(common::LLVM_LOCK_FILE)?;
     let path = file.parent().expect("Lockfile parent dir does not exist");
     cmd.current_dir(path);
@@ -48,8 +48,8 @@ fn build_without_clone() -> anyhow::Result<()> {
 #[rstest]
 #[timeout(std::time::Duration::from_secs(5000))]
 fn clone_build_and_clean() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(None)?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -58,14 +58,14 @@ fn clone_build_and_clean() -> anyhow::Result<()> {
     cmd.assert()
         .success()
         .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
-    let mut build_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut build_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     build_cmd.current_dir(test_dir);
     build_cmd
         .arg("build")
         .assert()
         .success()
         .stdout(predicate::str::is_match("Installing:.*").unwrap());
-    let mut clean_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut clean_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     clean_cmd.current_dir(test_dir);
     clean_cmd.arg("clean");
     clean_cmd.assert().success();
@@ -88,8 +88,8 @@ fn clone_build_and_clean() -> anyhow::Result<()> {
 #[rstest]
 #[timeout(std::time::Duration::from_secs(5000))]
 fn clone_build_and_clean_musl() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(None)?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -98,7 +98,7 @@ fn clone_build_and_clean_musl() -> anyhow::Result<()> {
     cmd.assert()
         .success()
         .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
-    let mut build_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut build_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     build_cmd.current_dir(test_dir);
     build_cmd
         .arg("build")
@@ -107,7 +107,7 @@ fn clone_build_and_clean_musl() -> anyhow::Result<()> {
         .assert()
         .success()
         .stdout(predicate::str::is_match("Installing:.*").unwrap());
-    let mut clean_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut clean_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     clean_cmd.current_dir(test_dir);
     clean_cmd.arg("clean");
     clean_cmd.assert().success();
@@ -130,8 +130,8 @@ fn clone_build_and_clean_musl() -> anyhow::Result<()> {
 #[rstest]
 #[timeout(std::time::Duration::from_secs(5000))]
 fn debug_build_with_tests_coverage() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(None)?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -140,7 +140,7 @@ fn debug_build_with_tests_coverage() -> anyhow::Result<()> {
     cmd.assert()
         .success()
         .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
-    let mut build_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut build_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     build_cmd.current_dir(test_dir);
     build_cmd
         .arg("build")

--- a/tests/checkout.rs
+++ b/tests/checkout.rs
@@ -34,10 +34,7 @@ fn checkout_after_clone() -> anyhow::Result<()> {
     let mut checkout_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     checkout_cmd.current_dir(test_dir);
     checkout_cmd.arg("checkout");
-    checkout_cmd
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("HEAD is now at"));
+    checkout_cmd.assert().success();
     Ok(())
 }
 
@@ -69,10 +66,7 @@ fn force_checkout() -> anyhow::Result<()> {
     let mut checkout_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     checkout_cmd.current_dir(test_dir);
     checkout_cmd.arg("checkout").arg("--force");
-    checkout_cmd
-        .assert()
-        .success()
-        .stderr(predicate::str::contains("HEAD is now at"));
+    checkout_cmd.assert().success();
     Ok(())
 }
 

--- a/tests/checkout.rs
+++ b/tests/checkout.rs
@@ -21,8 +21,8 @@ use rstest::rstest;
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn checkout_after_clone() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(None)?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -31,16 +31,13 @@ fn checkout_after_clone() -> anyhow::Result<()> {
     cmd.assert()
         .success()
         .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
-    let mut checkout_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut checkout_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     checkout_cmd.current_dir(test_dir);
     checkout_cmd.arg("checkout");
     checkout_cmd
         .assert()
         .success()
-        .stderr(predicate::str::contains(format!(
-            "HEAD is now at {}",
-            &common::ERA_LLVM_REPO_TEST_REF[..8]
-        )));
+        .stderr(predicate::str::contains("HEAD is now at"));
     Ok(())
 }
 
@@ -59,8 +56,8 @@ fn checkout_after_clone() -> anyhow::Result<()> {
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn force_checkout() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(None)?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -69,16 +66,13 @@ fn force_checkout() -> anyhow::Result<()> {
     cmd.assert()
         .success()
         .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
-    let mut checkout_cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut checkout_cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     checkout_cmd.current_dir(test_dir);
     checkout_cmd.arg("checkout").arg("--force");
     checkout_cmd
         .assert()
         .success()
-        .stderr(predicate::str::contains(format!(
-            "HEAD is now at {}",
-            &common::ERA_LLVM_REPO_TEST_REF[..8]
-        )));
+        .stderr(predicate::str::contains("HEAD is now at"));
     Ok(())
 }
 
@@ -97,7 +91,7 @@ fn force_checkout() -> anyhow::Result<()> {
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn checkout_without_lockfile() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     let file = assert_fs::NamedTempFile::new(common::LLVM_LOCK_FILE)?;
     let path = file.parent().expect("Lockfile parent dir does not exist");
     cmd.current_dir(path);

--- a/tests/clean.rs
+++ b/tests/clean.rs
@@ -21,7 +21,7 @@ use rstest::rstest;
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn clean_without_clone() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     let file = assert_fs::NamedTempFile::new(common::LLVM_LOCK_FILE)?;
     let path = file.parent().expect("Lockfile parent dir does not exist");
     cmd.current_dir(path);

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -21,8 +21,8 @@ use rstest::rstest;
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn clone() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(None)?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -30,10 +30,7 @@ fn clone() -> anyhow::Result<()> {
     cmd.arg("clone");
     cmd.assert()
         .success()
-        .stderr(predicate::str::contains(format!(
-            "HEAD is now at {}",
-            &common::ERA_LLVM_REPO_TEST_REF[..8]
-        )));
+        .stderr(predicate::str::contains("HEAD is now at"));
     Ok(())
 }
 
@@ -52,8 +49,8 @@ fn clone() -> anyhow::Result<()> {
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn clone_deep() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_REF)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile = common::create_test_tmp_lockfile(None)?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -62,10 +59,7 @@ fn clone_deep() -> anyhow::Result<()> {
     cmd.arg("--deep");
     cmd.assert()
         .success()
-        .stderr(predicate::str::contains(format!(
-            "HEAD is now at {}",
-            &common::ERA_LLVM_REPO_TEST_REF[..8]
-        )));
+        .stderr(predicate::str::contains("HEAD is now at"));
     Ok(())
 }
 
@@ -84,8 +78,9 @@ fn clone_deep() -> anyhow::Result<()> {
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn clone_wrong_reference() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
-    let lockfile = common::create_test_tmp_lockfile(common::ERA_LLVM_REPO_TEST_SHA_INVALID)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
+    let lockfile =
+        common::create_test_tmp_lockfile(Some(common::ERA_LLVM_REPO_TEST_SHA_INVALID.to_string()))?;
     let test_dir = lockfile
         .parent()
         .expect("Lockfile parent dir does not exist");
@@ -112,7 +107,7 @@ fn clone_wrong_reference() -> anyhow::Result<()> {
 /// Returns `Ok(())` if the test passes.
 #[rstest]
 fn clone_without_lockfile() -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     let file = assert_fs::NamedTempFile::new(common::LLVM_LOCK_FILE)?;
     let path = file.parent().expect("Lockfile parent dir does not exist");
     cmd.current_dir(path);

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -30,7 +30,7 @@ fn clone() -> anyhow::Result<()> {
     cmd.arg("clone");
     cmd.assert()
         .success()
-        .stderr(predicate::str::contains("HEAD is now at"));
+        .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
     Ok(())
 }
 
@@ -59,7 +59,7 @@ fn clone_deep() -> anyhow::Result<()> {
     cmd.arg("--deep");
     cmd.assert()
         .success()
-        .stderr(predicate::str::contains("HEAD is now at"));
+        .stderr(predicate::str::is_match(".*Updating files:.*100%.*done").unwrap());
     Ok(())
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,20 +1,21 @@
 use assert_fs::fixture::FileWriteStr;
 
-pub const ZKEVM_LLVM: &str = "zkevm-llvm";
+pub const ZKSYNC_LLVM: &str = "zksync-llvm";
 pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub const ERA_LLVM_REPO_URL: &str = "https://github.com/matter-labs/era-compiler-llvm";
 pub const ERA_LLVM_REPO_TEST_BRANCH: &str = "v1.4.2";
-pub const ERA_LLVM_REPO_TEST_REF: &str = "b5ccf6d5774e9bc3cee47ab4a334404718d3adfd";
 pub const ERA_LLVM_REPO_TEST_SHA_INVALID: &str = "12345abcd";
 pub const LLVM_LOCK_FILE: &str = "LLVM.lock";
 
 /// Creates a temporary lock file for testing.
-pub fn create_test_tmp_lockfile(reference: &str) -> anyhow::Result<assert_fs::NamedTempFile> {
+pub fn create_test_tmp_lockfile(
+    reference: Option<String>,
+) -> anyhow::Result<assert_fs::NamedTempFile> {
     let file = assert_fs::NamedTempFile::new(LLVM_LOCK_FILE)?;
     let lock = compiler_llvm_builder::Lock {
         url: ERA_LLVM_REPO_URL.to_string(),
         branch: ERA_LLVM_REPO_TEST_BRANCH.to_string(),
-        r#ref: Some(reference.to_string()),
+        r#ref: reference,
     };
     file.write_str(toml::to_string(&lock)?.as_str())?;
     Ok(file)

--- a/tests/invalid_invocation.rs
+++ b/tests/invalid_invocation.rs
@@ -30,7 +30,7 @@ use rstest::rstest;
 #[case("clone", "--invalid-clone-option")]
 #[case("checkout", "--invalid-checkout-option")]
 fn invalid_option(#[case] subcommand: &str, #[case] option: &str) -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     if subcommand != "" {
         cmd.arg(subcommand);
     }
@@ -65,7 +65,7 @@ fn invalid_option(#[case] subcommand: &str, #[case] option: &str) -> anyhow::Res
 #[case("123")]
 #[case("$$.@!;-a3")]
 fn invalid_subcommand(#[case] subcommand: &str) -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     cmd.arg(subcommand);
     cmd.assert()
         .failure()

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -30,7 +30,7 @@ use rstest::rstest;
 #[case("clone")]
 #[case("checkout")]
 fn version(#[case] subcommand: String) -> anyhow::Result<()> {
-    let mut cmd = Command::cargo_bin(common::ZKEVM_LLVM)?;
+    let mut cmd = Command::cargo_bin(common::ZKSYNC_LLVM)?;
     if subcommand != "" {
         cmd.arg(subcommand);
     }


### PR DESCRIPTION
# What ❔

* [x] Rename `zkevm-llvm` to `zksync-llvm`
* [x] Make tests independent from LLVM commit sha

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Fixes [CPR-1674](https://linear.app/matterlabs/issue/CPR-1674/make-compiler-builder-unit-tests-independent-from-the-commit)

To correspond to our new naming conventions and stabilize tests execution.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
