### PR TITLE
fix: check all retries in musl download condition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.23"
+version = "1.0.24"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.77.2"
+channel = "1.78.0"

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -47,7 +47,7 @@ pub fn build(
     if !LLVMPath::musl_source(musl_name)?.exists() {
         crate::utils::download_musl(musl_name)?;
     }
-    crate::utils::build_musl(musl_build.as_path(), musl_target.as_path())?;
+    crate::platforms::shared::build_musl(musl_build.as_path(), musl_target.as_path())?;
     build_crt(
         targets.clone(),
         llvm_host_module_llvm.as_path(),

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -47,7 +47,7 @@ pub fn build(
     if !LLVMPath::musl_source(musl_name)?.exists() {
         crate::utils::download_musl(musl_name)?;
     }
-    crate::utils::build_musl(musl_build.as_path(), musl_target.as_path())?;
+    crate::platforms::shared::build_musl(musl_build.as_path(), musl_target.as_path())?;
     build_crt(
         targets.clone(),
         llvm_host_module_llvm.as_path(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -86,7 +86,7 @@ pub fn download(url: &str, path: &str) -> anyhow::Result<()> {
                     .all(|(_, status)| status == &http::status::StatusCode::OK)
             })
         })
-        .any(|result| result.is_ok())
+        .all(|result| result.is_err())
     {
         anyhow::bail!("MUSL download from `{url}` failed: {:?}", results);
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -75,12 +75,12 @@ pub fn download(url: &str, path: &str) -> anyhow::Result<()> {
     let dl = downloader::Download::new(url);
     for r in downloader.download(&[dl])? {
         let summary = r.map_err(|error| anyhow::anyhow!("{}", error))?;
-        for download_result in summary.status {
-            let url = download_result.0;
-            let http_result = download_result.1;
-            if http_result != http::status::StatusCode::OK {
-                anyhow::bail!("{url} failed with HTTP code: {http_result}");
-            }
+        if !summary
+            .status
+            .iter()
+            .any(|&(_, status)| status == http::status::StatusCode::OK)
+        {
+            anyhow::bail!("MUSL download failed! for {}", url);
         }
     }
     Ok(())


### PR DESCRIPTION
# What ❔

Checks all conditions for Musl download retries.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

The tool was panicking if any attempt to download Musl failed even if a retry succeeds. This fixes this behavior by checking all attempts and failing only if all of them failed.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
