### PR TITLE
feat: add LLVM_ENABLE_WERROR and CMAKE_EXPORT_COMPILE_COMMANDS to default flags

### DIFF
--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// The build options shared by all platforms.
-pub const SHARED_BUILD_OPTS: [&str; 16] = [
+pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
     "-DLLVM_BUILD_DOCS='Off'",
@@ -25,6 +25,8 @@ pub const SHARED_BUILD_OPTS: [&str; 16] = [
     "-DLLVM_ENABLE_TERMINFO='Off'",
     "-DLLVM_ENABLE_LIBEDIT='Off'",
     "-DLLVM_ENABLE_LIBPFM='Off'",
+    "-DLLVM_ENABLE_WERROR='On'",
+    "-DCMAKE_EXPORT_COMPILE_COMMANDS='On'",
 ];
 
 /// The build options shared by all platforms except MUSL.


### PR DESCRIPTION
# What ❔

Add `LLVM_ENABLE_WERROR` and `CMAKE_EXPORT_COMPILE_COMMANDS` to default cmake flags.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

These are additional parameters we always use for our builds, make them default instead of always specifying them explicitly across the ecosystem.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
