### PR TITLE
fix: set LLVM_DEFAULT_TARGET_TRIPLE to always be lowercase

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.27"
+version = "1.0.28"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.27"
+version = "1.0.28"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,8 @@ pub mod llvm_path;
 pub mod lock;
 pub mod platforms;
 pub mod sanitizer;
+pub mod target_env;
+pub mod target_triple;
 pub mod utils;
 
 pub use self::build_type::BuildType;
@@ -17,6 +19,7 @@ pub use self::platforms::Platform;
 use std::collections::HashSet;
 use std::path::PathBuf;
 use std::process::Command;
+pub use target_triple::TargetTriple;
 
 ///
 /// Executes the LLVM host repository cloning for stage 1 MUSL builds.
@@ -50,11 +53,11 @@ pub fn clone_host() -> anyhow::Result<()> {
 ///
 /// Executes the LLVM repository cloning.
 ///
-pub fn clone(lock: Lock, deep: bool, target_env: platforms::TargetEnv) -> anyhow::Result<()> {
+pub fn clone(lock: Lock, deep: bool, target_env: target_env::TargetEnv) -> anyhow::Result<()> {
     utils::check_presence("git")?;
 
     // Clone the host repository if the target is musl.
-    if cfg!(target_os = "linux") && target_env == platforms::TargetEnv::MUSL {
+    if cfg!(target_os = "linux") && target_env == target_env::TargetEnv::MUSL {
         clone_host()?;
     }
 
@@ -144,9 +147,9 @@ pub fn checkout(lock: Lock, force: bool) -> anyhow::Result<()> {
 #[allow(clippy::too_many_arguments)]
 pub fn build(
     build_type: BuildType,
-    target_env: platforms::TargetEnv,
+    target_env: target_env::TargetEnv,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -158,7 +161,7 @@ pub fn build(
 
     if cfg!(target_arch = "x86_64") {
         if cfg!(target_os = "linux") {
-            if target_env == platforms::TargetEnv::MUSL {
+            if target_env == target_env::TargetEnv::MUSL {
                 platforms::x86_64_linux_musl::build(
                     build_type,
                     targets,
@@ -170,7 +173,7 @@ pub fn build(
                     enable_assertions,
                     sanitizer,
                 )?;
-            } else if target_env == platforms::TargetEnv::GNU {
+            } else if target_env == target_env::TargetEnv::GNU {
                 platforms::x86_64_linux_gnu::build(
                     build_type,
                     targets,
@@ -214,7 +217,7 @@ pub fn build(
         }
     } else if cfg!(target_arch = "aarch64") {
         if cfg!(target_os = "linux") {
-            if target_env == platforms::TargetEnv::MUSL {
+            if target_env == target_env::TargetEnv::MUSL {
                 platforms::aarch64_linux_musl::build(
                     build_type,
                     targets,
@@ -226,7 +229,7 @@ pub fn build(
                     enable_assertions,
                     sanitizer,
                 )?;
-            } else if target_env == platforms::TargetEnv::GNU {
+            } else if target_env == target_env::TargetEnv::GNU {
                 platforms::aarch64_linux_gnu::build(
                     build_type,
                     targets,

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -9,6 +9,7 @@ use crate::build_type::BuildType;
 use crate::llvm_path::LLVMPath;
 use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
+use crate::target_triple::TargetTriple;
 
 ///
 /// The building sequence.
@@ -17,7 +18,7 @@ use crate::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -10,6 +10,7 @@ use crate::build_type::BuildType;
 use crate::llvm_path::LLVMPath;
 use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
+use crate::target_triple::TargetTriple;
 
 ///
 /// The building sequence.
@@ -18,7 +19,7 @@ use crate::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -258,7 +259,7 @@ fn build_host(
 fn build_target(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -9,6 +9,7 @@ use crate::build_type::BuildType;
 use crate::llvm_path::LLVMPath;
 use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
+use crate::target_triple::TargetTriple;
 
 ///
 /// The building sequence.
@@ -17,7 +18,7 @@ use crate::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -28,29 +28,6 @@ pub enum Platform {
     EVM,
 }
 
-///
-/// The list of target environments used as constants.
-///
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum TargetEnv {
-    /// The GNU target environment.
-    GNU,
-    /// The MUSL target environment.
-    MUSL,
-}
-
-impl FromStr for TargetEnv {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "gnu" => Ok(Self::GNU),
-            "musl" => Ok(Self::MUSL),
-            value => Err(format!("Unsupported target environment: `{}`", value)),
-        }
-    }
-}
-
 impl FromStr for Platform {
     type Err = String;
 

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -3,7 +3,7 @@
 //!
 
 use crate::sanitizer::Sanitizer;
-use crate::Platform;
+use crate::target_triple::TargetTriple;
 use std::path::Path;
 use std::process::Command;
 
@@ -40,7 +40,7 @@ pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 4] = [
 ///
 /// The build options to set the default target.
 ///
-pub fn shared_build_opts_default_target(target: Option<Platform>) -> Vec<String> {
+pub fn shared_build_opts_default_target(target: Option<TargetTriple>) -> Vec<String> {
     match target {
         Some(target) => vec![format!(
             "-DLLVM_DEFAULT_TARGET_TRIPLE='{}'",
@@ -48,7 +48,7 @@ pub fn shared_build_opts_default_target(target: Option<Platform>) -> Vec<String>
         )],
         None => vec![format!(
             "-DLLVM_DEFAULT_TARGET_TRIPLE='{}'",
-            Platform::EraVM
+            TargetTriple::EraVM
         )],
     }
 }

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -9,6 +9,7 @@ use crate::build_type::BuildType;
 use crate::llvm_path::LLVMPath;
 use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
+use crate::target_triple::TargetTriple;
 
 ///
 /// The building sequence.
@@ -17,7 +18,7 @@ use crate::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -10,6 +10,7 @@ use crate::build_type::BuildType;
 use crate::llvm_path::LLVMPath;
 use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
+use crate::target_triple::TargetTriple;
 
 ///
 /// The building sequence.
@@ -18,7 +19,7 @@ use crate::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,
@@ -257,7 +258,7 @@ fn build_host(
 fn build_target(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     source_directory: &Path,
     build_directory: &Path,
     target_directory: &Path,

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -9,6 +9,7 @@ use crate::build_type::BuildType;
 use crate::llvm_path::LLVMPath;
 use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
+use crate::target_triple::TargetTriple;
 
 ///
 /// The building sequence.
@@ -17,7 +18,7 @@ use crate::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -10,6 +10,7 @@ use crate::build_type::BuildType;
 use crate::llvm_path::LLVMPath;
 use crate::platforms::Platform;
 use crate::sanitizer::Sanitizer;
+use crate::target_triple::TargetTriple;
 
 ///
 /// The building sequence.
@@ -18,7 +19,7 @@ use crate::sanitizer::Sanitizer;
 pub fn build(
     build_type: BuildType,
     targets: HashSet<Platform>,
-    default_target: Option<Platform>,
+    default_target: Option<TargetTriple>,
     enable_tests: bool,
     enable_coverage: bool,
     extra_args: Vec<String>,

--- a/src/target_env.rs
+++ b/src/target_env.rs
@@ -1,0 +1,26 @@
+//!
+//! The target environments to build LLVM.
+//!
+
+///
+/// The list of target environments used as constants.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TargetEnv {
+    /// The GNU target environment.
+    GNU,
+    /// The MUSL target environment.
+    MUSL,
+}
+
+impl std::str::FromStr for TargetEnv {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "gnu" => Ok(Self::GNU),
+            "musl" => Ok(Self::MUSL),
+            value => Err(format!("Unsupported target environment: `{}`", value)),
+        }
+    }
+}

--- a/src/target_triple.rs
+++ b/src/target_triple.rs
@@ -1,0 +1,37 @@
+//!
+//! The ZKsync LLVM target triples.
+//!
+
+///
+/// The list of target triples used as constants.
+///
+/// It must be in the lowercase.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TargetTriple {
+    /// The EraVM back end developed by Matter Labs.
+    EraVM,
+    /// The EVM back end developed by Matter Labs.
+    EVM,
+}
+
+impl std::str::FromStr for TargetTriple {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "eravm" => Ok(Self::EraVM),
+            "evm" => Ok(Self::EVM),
+            value => Err(format!("Unsupported target triple: `{}`", value)),
+        }
+    }
+}
+
+impl std::fmt::Display for TargetTriple {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::EraVM => write!(f, "eravm"),
+            Self::EVM => write!(f, "evm"),
+        }
+    }
+}

--- a/src/zksync_llvm/arguments.rs
+++ b/src/zksync_llvm/arguments.rs
@@ -17,7 +17,7 @@ pub enum Arguments {
         deep: bool,
         /// Target environment to build LLVM (GNU or MUSL).
         #[structopt(long = "target-env", default_value = "gnu")]
-        target_env: compiler_llvm_builder::platforms::TargetEnv,
+        target_env: compiler_llvm_builder::target_env::TargetEnv,
     },
     /// Build the LLVM framework.
     Build {
@@ -26,13 +26,13 @@ pub enum Arguments {
         debug: bool,
         /// Target environment to build LLVM (`gnu` or `musl`).
         #[structopt(long = "target-env", default_value = "gnu")]
-        target_env: compiler_llvm_builder::platforms::TargetEnv,
+        target_env: compiler_llvm_builder::target_env::TargetEnv,
         /// Additional targets to build LLVM with.
         #[structopt(long = "targets", multiple = true)]
         targets: Vec<String>,
         /// The default target to build LLVM with.
         #[structopt(long = "default-target")]
-        default_target: Option<compiler_llvm_builder::platforms::Platform>,
+        default_target: Option<compiler_llvm_builder::target_triple::TargetTriple>,
         /// Whether to build the LLVM tests.
         #[structopt(long = "enable-tests")]
         enable_tests: bool,


### PR DESCRIPTION
# What ❔

Introduce a new `TargetTriple` enum for triple values, as the `Platform` is different from the triple, and `EraVM`/`EVM` targets cannot be used as a triple value, they should be lowercase.

Decided to implement as a separate enum, because triple and platform values can differ, and converting `Platform` to the lowercase can break in the future.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix `llc` behavior when triple is not lowercase as LLVM cannot handle this.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
