### PR TITLE
fix: build crt profile for coverage support on musl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.28"
+version = "1.0.29"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -774,9 +774,9 @@ checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.5.0",
  "cfg-if",
@@ -806,9 +806,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.102"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.28"
+version = "1.0.29"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -214,7 +214,7 @@ fn build_host(
                 "-DCOMPILER_RT_BUILD_SANITIZERS='Off'",
                 "-DCOMPILER_RT_BUILD_XRAY='Off'",
                 "-DCOMPILER_RT_BUILD_LIBFUZZER='Off'",
-                "-DCOMPILER_RT_BUILD_PROFILE='Off'",
+                "-DCOMPILER_RT_BUILD_PROFILE='On'",
                 "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
                 "-DCOMPILER_RT_BUILD_ORC='Off'",
                 "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='aarch64'",

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -213,7 +213,7 @@ fn build_host(
                 "-DCOMPILER_RT_BUILD_SANITIZERS='Off'",
                 "-DCOMPILER_RT_BUILD_XRAY='Off'",
                 "-DCOMPILER_RT_BUILD_LIBFUZZER='Off'",
-                "-DCOMPILER_RT_BUILD_PROFILE='Off'",
+                "-DCOMPILER_RT_BUILD_PROFILE='On'",
                 "-DCOMPILER_RT_BUILD_MEMPROF='Off'",
                 "-DCOMPILER_RT_BUILD_ORC='Off'",
                 "-DCOMPILER_RT_DEFAULT_TARGET_ARCH='x86_64'",


### PR DESCRIPTION
# What ❔

Build compiler-rt profile library for stage1 musl builds.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To fix `--enable-coverage` option under Musl targets.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
