### PR TITLE
feat: support all LLVM build types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.29"
+version = "1.0.30"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.29"
+version = "1.0.30"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/build_type.rs
+++ b/src/build_type.rs
@@ -11,14 +11,22 @@ pub enum BuildType {
     Debug,
     /// The release build.
     Release,
+    /// The release with debug info build.
+    RelWithDebInfo,
+    /// The minimal size release build.
+    MinSizeRel,
 }
 
-impl From<bool> for BuildType {
-    fn from(is_debug: bool) -> Self {
-        if is_debug {
-            Self::Debug
-        } else {
-            Self::Release
+impl std::str::FromStr for BuildType {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "Debug" => Ok(Self::Debug),
+            "Release" => Ok(Self::Release),
+            "RelWithDebInfo" => Ok(Self::RelWithDebInfo),
+            "MinSizeRel" => Ok(Self::MinSizeRel),
+            value => Err(format!("Unsupported build type: `{}`", value)),
         }
     }
 }
@@ -28,6 +36,8 @@ impl std::fmt::Display for BuildType {
         match self {
             Self::Debug => write!(f, "Debug"),
             Self::Release => write!(f, "Release"),
+            Self::RelWithDebInfo => write!(f, "RelWithDebInfo"),
+            Self::MinSizeRel => write!(f, "MinSizeRel"),
         }
     }
 }

--- a/src/zksync_llvm/arguments.rs
+++ b/src/zksync_llvm/arguments.rs
@@ -21,9 +21,9 @@ pub enum Arguments {
     },
     /// Build the LLVM framework.
     Build {
-        /// Whether to build the 'Debug' version.
-        #[structopt(long = "debug")]
-        debug: bool,
+        /// LLVM build type (`Debug`, `Release`, `RelWithDebInfo`, or `MinSizeRel`).
+        #[structopt(long = "build-type", default_value = "Release")]
+        build_type: compiler_llvm_builder::BuildType,
         /// Target environment to build LLVM (`gnu` or `musl`).
         #[structopt(long = "target-env", default_value = "gnu")]
         target_env: compiler_llvm_builder::target_env::TargetEnv,

--- a/src/zksync_llvm/main.rs
+++ b/src/zksync_llvm/main.rs
@@ -48,7 +48,7 @@ fn main_inner() -> anyhow::Result<()> {
             compiler_llvm_builder::clone(lock, deep, target_env)?;
         }
         Arguments::Build {
-            debug,
+            build_type,
             target_env,
             targets,
             default_target,
@@ -59,8 +59,6 @@ fn main_inner() -> anyhow::Result<()> {
             enable_assertions,
             sanitizer,
         } => {
-            let build_type = compiler_llvm_builder::BuildType::from(debug);
-
             let mut targets = targets
                 .into_iter()
                 .map(|target| compiler_llvm_builder::Platform::from_str(target.as_str()))

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -146,7 +146,8 @@ fn debug_build_with_tests_coverage() -> anyhow::Result<()> {
         .arg("build")
         .arg("--enable-coverage")
         .arg("--enable-tests")
-        .arg("--debug");
+        .arg("--build-type")
+        .arg("Debug");
     build_cmd
         .assert()
         .success()


### PR DESCRIPTION
# What ❔

Support two additional build types `RelWithDebInfo` and `MinSizeRel`.
<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Sometimes, these build types can be required in debugging purposes.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
