### PR TITLE
feat: add capability to run LLVM regression tests under valgrind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.30"
+version = "1.0.31"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.30"
+version = "1.0.31"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,7 @@ pub fn build(
     use_ccache: bool,
     enable_assertions: bool,
     sanitizer: Option<sanitizer::Sanitizer>,
+    enable_valgrind: bool,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
 
@@ -172,6 +173,7 @@ pub fn build(
                     use_ccache,
                     enable_assertions,
                     sanitizer,
+                    enable_valgrind,
                 )?;
             } else if target_env == target_env::TargetEnv::GNU {
                 platforms::x86_64_linux_gnu::build(
@@ -184,6 +186,7 @@ pub fn build(
                     use_ccache,
                     enable_assertions,
                     sanitizer,
+                    enable_valgrind,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for x86_64 and Linux");
@@ -228,6 +231,7 @@ pub fn build(
                     use_ccache,
                     enable_assertions,
                     sanitizer,
+                    enable_valgrind,
                 )?;
             } else if target_env == target_env::TargetEnv::GNU {
                 platforms::aarch64_linux_gnu::build(
@@ -240,6 +244,7 @@ pub fn build(
                     use_ccache,
                     enable_assertions,
                     sanitizer,
+                    enable_valgrind,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for aarch64 and Linux");

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -25,6 +25,7 @@ pub fn build(
     use_ccache: bool,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -85,6 +86,9 @@ pub fn build(
             ))
             .args(crate::platforms::shared::shared_build_opts_sanitizers(
                 sanitizer,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_valgrind(
+                enable_valgrind,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -26,6 +26,7 @@ pub fn build(
     use_ccache: bool,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -83,6 +84,7 @@ pub fn build(
         use_ccache,
         enable_assertions,
         sanitizer,
+        enable_valgrind,
     )?;
 
     Ok(())
@@ -271,6 +273,7 @@ fn build_target(
     use_ccache: bool,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -335,6 +338,9 @@ fn build_target(
             ))
             .args(crate::platforms::shared::shared_build_opts_sanitizers(
                 sanitizer,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_valgrind(
+                enable_valgrind,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -146,6 +146,17 @@ pub fn shared_build_opts_sanitizers(sanitizer: Option<Sanitizer>) -> Vec<String>
 }
 
 ///
+/// The build options to enable Valgrind for LLVM regression tests.
+///
+pub fn shared_build_opts_valgrind(enabled: bool) -> Vec<String> {
+    if enabled {
+        vec!["-DLLVM_LIT_ARGS='-sv --vg --vg-leak'".to_owned()]
+    } else {
+        vec![]
+    }
+}
+
+///
 /// The LLVM tests build options shared by all platforms.
 ///
 pub fn shared_build_opts_tests(enabled: bool) -> Vec<String> {

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -25,6 +25,7 @@ pub fn build(
     use_ccache: bool,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -85,6 +86,9 @@ pub fn build(
             ))
             .args(crate::platforms::shared::shared_build_opts_sanitizers(
                 sanitizer,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_valgrind(
+                enable_valgrind,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -26,6 +26,7 @@ pub fn build(
     use_ccache: bool,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -83,6 +84,7 @@ pub fn build(
         use_ccache,
         enable_assertions,
         sanitizer,
+        enable_valgrind,
     )?;
 
     Ok(())
@@ -270,6 +272,7 @@ fn build_target(
     use_ccache: bool,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
+    enable_valgrind: bool,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -334,6 +337,9 @@ fn build_target(
             ))
             .args(crate::platforms::shared::shared_build_opts_sanitizers(
                 sanitizer,
+            ))
+            .args(crate::platforms::shared::shared_build_opts_valgrind(
+                enable_valgrind,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/zksync_llvm/arguments.rs
+++ b/src/zksync_llvm/arguments.rs
@@ -52,6 +52,9 @@ pub enum Arguments {
         /// Build LLVM with sanitizer enabled (`Address`, `Memory`, `MemoryWithOrigins`, `Undefined`, `Thread`, `DataFlow`, or `Address;Undefined`).
         #[structopt(long = "sanitizer")]
         sanitizer: Option<compiler_llvm_builder::sanitizer::Sanitizer>,
+        /// Whether to run LLVM unit tests under valgrind or not.
+        #[structopt(long = "enable-valgrind")]
+        enable_valgrind: bool,
     },
     /// Checkout the branch specified in `LLVM.lock`.
     Checkout {

--- a/src/zksync_llvm/main.rs
+++ b/src/zksync_llvm/main.rs
@@ -58,6 +58,7 @@ fn main_inner() -> anyhow::Result<()> {
             use_ccache,
             enable_assertions,
             sanitizer,
+            enable_valgrind,
         } => {
             let mut targets = targets
                 .into_iter()
@@ -96,6 +97,7 @@ fn main_inner() -> anyhow::Result<()> {
                 use_ccache,
                 enable_assertions,
                 sanitizer,
+                enable_valgrind,
             )?;
         }
         Arguments::Checkout { force } => {


### PR DESCRIPTION
# What ❔

Add the capability to run LLVM regression tests under `valgrind` if necessary.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow developers to find memory-related issues with LLVM.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
