### PR TITLE
chore: disable -Werror on Windows due to msys2 dll import issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.31"
+version = "1.0.32"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -77,6 +77,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(crate::platforms::shared::shared_build_opts_werror())
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -323,6 +323,7 @@ fn build_target(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(crate::platforms::shared::shared_build_opts_werror())
             .args(crate::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -71,6 +71,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(crate::platforms::shared::shared_build_opts_werror())
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// The build options shared by all platforms.
-pub const SHARED_BUILD_OPTS: [&str; 18] = [
+pub const SHARED_BUILD_OPTS: [&str; 17] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
     "-DLLVM_BUILD_DOCS='Off'",
@@ -25,7 +25,6 @@ pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DLLVM_ENABLE_TERMINFO='Off'",
     "-DLLVM_ENABLE_LIBEDIT='Off'",
     "-DLLVM_ENABLE_LIBPFM='Off'",
-    "-DLLVM_ENABLE_WERROR='On'",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS='On'",
 ];
 
@@ -36,6 +35,23 @@ pub const SHARED_BUILD_OPTS_NOT_MUSL: [&str; 4] = [
     "-DLLVM_BUILD_RUNTIMES='Off'",
     "-DLLVM_INCLUDE_RUNTIMES='Off'",
 ];
+
+///
+/// The shared build options to treat warnings as errors.
+///
+/// Disabled on Windows due to the following upstream issue with MSYS2 with mingw-w64:
+/// ProgramTest.cpp:23:15: error: '__p__environ' redeclared without 'dllimport' attribute
+///
+pub fn shared_build_opts_werror() -> Vec<String> {
+    vec![format!(
+        "-DLLVM_ENABLE_WERROR='{}'",
+        if cfg!(target_os = "windows") {
+            "Off"
+        } else {
+            "On"
+        },
+    )]
+}
 
 ///
 /// The build options to set the default target.

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -80,6 +80,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(crate::platforms::shared::shared_build_opts_werror())
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -322,6 +322,7 @@ fn build_target(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(crate::platforms::shared::shared_build_opts_werror())
             .args(crate::platforms::shared::shared_build_opts_tests(
                 enable_tests,
             ))

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -71,6 +71,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(crate::platforms::shared::shared_build_opts_werror())
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -80,6 +80,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)
+            .args(crate::platforms::shared::shared_build_opts_werror())
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,


### PR DESCRIPTION
# What ❔

Disable `-DLLVM_ENABLE_WERROR` on Windows due to an issue with upstream LLVM unit tests compilation on MSYS2:

```
../../llvm/llvm/unittests/Support/ProgramTest.cpp:23:15: error: '__p__environ' redeclared without 'dllimport' attribute: previous 'dllimport' ignored [-Werror,-Winconsistent-dllimport]
   23 | extern char **environ;
      |               ^
C:/a/_temp/msys64/mingw64/include/stdlib.h:598:17: note: expanded from macro 'environ'
  598 | #define environ _environ
      |                 ^
C:/a/_temp/msys64/mingw64/include/stdlib.h:225:21: note: expanded from macro '_environ'
  225 | #define _environ (* __p__environ())
      |                     ^
C:/a/_temp/msys64/mingw64/include/stdlib.h:221:27: note: previous declaration is here
  221 |   _CRTIMP char ***__cdecl __p__environ(void);
      |                           ^
C:/a/_temp/msys64/mingw64/include/stdlib.h:221:3: note: previous attribute is here
  221 |   _CRTIMP char ***__cdecl __p__environ(void);

      |   ^

C:/a/_temp/msys64/mingw64/include/_mingw.h:52:40: note: expanded from macro '_CRTIMP'

   52 | #      define _CRTIMP  __attribute__ ((__dllimport__))

      |                                        ^

1 error generated.
```

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To Windows testing and verification.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
