### PR TITLE
chore: remove gnu condition from Windows

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -43,7 +43,7 @@ jobs:
         include:
           - name: "Linux x86_64"
             image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
-            runner: matterlabs-ci-runner
+            runner: matterlabs-ci-runner-high-performance
           - name: "Linux aarch64"
             image: matterlabs/llvm_runner:ubuntu22-llvm17-latest
             runner: matterlabs-ci-runner-arm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.31"
+version = "1.0.33"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.32"
+version = "1.0.33"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@ pub fn build(
                 enable_assertions,
                 sanitizer,
             )?;
-        } else if cfg!(target_os = "windows") && cfg!(target_env = "gnu") {
+        } else if cfg!(target_os = "windows") {
             platforms::x86_64_windows_gnu::build(
                 build_type,
                 targets,


### PR DESCRIPTION
# What ❔

Remove `gnu` condition from the Windows build branch.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

In some cases where `gnu` is undefined:
["For historical reasons, this value is only defined as not the empty-string when actually needed for disambiguation. Thus, for example, on many GNU platforms, this value will be empty."
](https://doc.rust-lang.org/reference/conditional-compilation.html#target_env:~:text=or%20libc%20used.-,For%20historical%20reasons%2C%20this%20value%20is%20only%20defined%20as%20not%20the%20empty%2Dstring%20when%20actually%20needed%20for%20disambiguation.%20Thus%2C%20for%20example%2C%20on%20many%20GNU%20platforms%2C%20this%20value%20will%20be%20empty.,-This%20value%20is)

This is required to properly fix MSYS2 regression tests on Windows.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
