### PR TITLE
fix: use python from PATH and not from registry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 
 [[package]]
 name = "compiler-llvm-builder"
-version = "1.0.33"
+version = "1.0.34"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.33"
+version = "1.0.34"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// The build options shared by all platforms.
-pub const SHARED_BUILD_OPTS: [&str; 17] = [
+pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
     "-DLLVM_BUILD_DOCS='Off'",
@@ -26,6 +26,7 @@ pub const SHARED_BUILD_OPTS: [&str; 17] = [
     "-DLLVM_ENABLE_LIBEDIT='Off'",
     "-DLLVM_ENABLE_LIBPFM='Off'",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS='On'",
+    "-DPython3_FIND_REGISTRY='LAST'", // Use Python version from PATH, and not from registry
 ];
 
 /// The build options shared by all platforms except MUSL.


### PR DESCRIPTION
# What ❔

Use python from PATH, and not from registry.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

Unfortunately, just adding the right python in PATH is not enough, and to not implement workarounds and also fix potential Windows Python discovery issues for our users, we need to remove CMake python search from registry on Windows:
* https://github.com/actions/setup-python/issues/186
* https://cmake.org/cmake/help/v3.12/module/FindPython.html

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
