### PR TITLE
fix: remove windows custom libstdc++

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.35"
+version = "1.0.36"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -3,7 +3,6 @@
 //!
 
 use std::collections::HashSet;
-use std::path::PathBuf;
 use std::process::Command;
 
 use crate::build_type::BuildType;
@@ -109,20 +108,6 @@ pub fn build(
     )?;
 
     crate::utils::ninja(llvm_build_final.as_ref())?;
-
-    let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
-        Ok(libstdcpp_source_path) => PathBuf::from(libstdcpp_source_path),
-        Err(error) => anyhow::bail!(
-            "The `LIBSTDCPP_SOURCE_PATH` must be set to the path to the libstdc++.a static library: {}", error
-        ),
-    };
-    let mut libstdcpp_destination_path = llvm_target_final;
-    libstdcpp_destination_path.push("./lib/libstdc++.a");
-    fs_extra::file::copy(
-        crate::utils::path_windows_to_unix(libstdcpp_source_path)?,
-        crate::utils::path_windows_to_unix(libstdcpp_destination_path)?,
-        &fs_extra::file::CopyOptions::default(),
-    )?;
 
     Ok(())
 }


### PR DESCRIPTION
# What ❔

Remove unnecessary `libstdc++` copying on Windows.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

This copying causes issues with duplicated symbols like: `multiple definition of std::__cxx11::basic_string`.
Example of the problem: https://github.com/matter-labs/era-compiler-llvm/actions/runs/10887318886/job/30209296538

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
