### PR TITLE
Revert "fix: remove windows custom libstdc++ (#42)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compiler-llvm-builder"
-version = "1.0.36"
+version = "1.0.35"
 authors = [
     "Oleksandr Zarudnyi <a.zarudnyy@matterlabs.dev>",
     "Anton Baliasnikov <aba@matterlabs.dev>",

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -3,6 +3,7 @@
 //!
 
 use std::collections::HashSet;
+use std::path::PathBuf;
 use std::process::Command;
 
 use crate::build_type::BuildType;
@@ -108,6 +109,20 @@ pub fn build(
     )?;
 
     crate::utils::ninja(llvm_build_final.as_ref())?;
+
+    let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
+        Ok(libstdcpp_source_path) => PathBuf::from(libstdcpp_source_path),
+        Err(error) => anyhow::bail!(
+            "The `LIBSTDCPP_SOURCE_PATH` must be set to the path to the libstdc++.a static library: {}", error
+        ),
+    };
+    let mut libstdcpp_destination_path = llvm_target_final;
+    libstdcpp_destination_path.push("./lib/libstdc++.a");
+    fs_extra::file::copy(
+        crate::utils::path_windows_to_unix(libstdcpp_source_path)?,
+        crate::utils::path_windows_to_unix(libstdcpp_destination_path)?,
+        &fs_extra::file::CopyOptions::default(),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
# What ❔

This reverts commit fb986a43c44e2ae056484504b83cbae3a3aa71fa.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

* We were copying GNU libstdc++ static lib from msys64/mingw to the LLVM folder with static libs.
* llvm-sys takes this libstdc++ just because it's in this directory and links with it
* additionally, llvm-sys build.rs adds dynamic libstdc++ to be linked on Windows
* +crt-static Rust flag is not recognizable by build.rs on Windows

Although it can cause some issues with tester (due to dynamic and static linkage mix), there is no beautiful and other way for now to link properly. It's better to revert now to unblock testing and releases in zksolc/zkvyper.

Related issue: https://github.com/rust-lang/rust/issues/24345

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
