### PR TITLE
feat: support of sccache compiler cache variant

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 profile = "default"
-channel = "1.78.0"
+channel = "1.82.0"

--- a/src/ccache_variant.rs
+++ b/src/ccache_variant.rs
@@ -1,0 +1,35 @@
+//!
+//! Compiler cache variants.
+//!
+
+///
+/// The list compiler cache variants to be used as constants.
+///
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CcacheVariant {
+    /// Standard ccache.
+    Ccache,
+    /// Mozilla's sccache.
+    Sccache,
+}
+
+impl std::str::FromStr for CcacheVariant {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "ccache" => Ok(Self::Ccache),
+            "sccache" => Ok(Self::Sccache),
+            value => Err(format!("Unsupported ccache variant: `{}`", value)),
+        }
+    }
+}
+
+impl std::fmt::Display for CcacheVariant {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Ccache => write!(f, "ccache"),
+            Self::Sccache => write!(f, "sccache"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //!
 
 pub mod build_type;
+pub mod ccache_variant;
 pub mod llvm_path;
 pub mod llvm_project;
 pub mod lock;
@@ -157,6 +158,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<sanitizer::Sanitizer>,
     enable_valgrind: bool,
@@ -176,6 +178,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    ccache_variant,
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
@@ -191,6 +194,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    ccache_variant,
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
@@ -209,6 +213,7 @@ pub fn build(
                 enable_coverage,
                 extra_args,
                 use_ccache,
+                ccache_variant,
                 enable_assertions,
                 sanitizer,
             )?;
@@ -223,6 +228,7 @@ pub fn build(
                 enable_coverage,
                 extra_args,
                 use_ccache,
+                ccache_variant,
                 enable_assertions,
                 sanitizer,
             )?;
@@ -242,6 +248,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    ccache_variant,
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
@@ -257,6 +264,7 @@ pub fn build(
                     enable_coverage,
                     extra_args,
                     use_ccache,
+                    ccache_variant,
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
@@ -275,6 +283,7 @@ pub fn build(
                 enable_coverage,
                 extra_args,
                 use_ccache,
+                ccache_variant,
                 enable_assertions,
                 sanitizer,
             )?;

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
+use crate::ccache_variant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
 use crate::platforms::Platform;
@@ -26,6 +27,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
@@ -92,6 +94,7 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -3,6 +3,7 @@
 //!
 
 use crate::build_type::BuildType;
+use crate::ccache_variant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
 use crate::platforms::Platform;
@@ -26,6 +27,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
@@ -62,6 +64,7 @@ pub fn build(
         llvm_build_crt.as_path(),
         llvm_target_crt.as_path(),
         use_ccache,
+        ccache_variant,
     )?;
     build_host(
         llvm_host_module_llvm.as_path(),
@@ -70,6 +73,7 @@ pub fn build(
         musl_target.as_path(),
         llvm_target_crt.as_path(),
         use_ccache,
+        ccache_variant,
     )?;
     build_target(
         build_type,
@@ -86,6 +90,7 @@ pub fn build(
         enable_coverage,
         extra_args,
         use_ccache,
+        ccache_variant,
         enable_assertions,
         sanitizer,
         enable_valgrind,
@@ -103,6 +108,7 @@ fn build_crt(
     build_directory: &Path,
     target_directory: &Path,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
 ) -> anyhow::Result<()> {
     targets.insert(Platform::AArch64);
 
@@ -145,6 +151,7 @@ fn build_crt(
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             )),
         "CRT building cmake",
     )?;
@@ -170,6 +177,7 @@ fn build_host(
     musl_target_directory: &Path,
     crt_target_directory: &Path,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
 ) -> anyhow::Result<()> {
     crate::utils::command(
         Command::new("cmake")
@@ -229,6 +237,7 @@ fn build_host(
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             )),
         "LLVM host building cmake",
     )?;
@@ -277,6 +286,7 @@ fn build_target(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
@@ -347,6 +357,7 @@ fn build_target(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
+use crate::ccache_variant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
 use crate::platforms::Platform;
@@ -26,6 +27,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
 ) -> anyhow::Result<()> {
@@ -86,6 +88,7 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -2,6 +2,7 @@
 //! The shared options for building various platforms.
 //!
 
+use crate::ccache_variant::CcacheVariant;
 use crate::sanitizer::Sanitizer;
 use crate::target_triple::TargetTriple;
 use std::path::Path;
@@ -220,11 +221,11 @@ pub fn shared_build_opts_coverage(enabled: bool) -> Vec<String> {
 ///
 /// Use of compiler cache (ccache) to speed up the build process.
 ///
-pub fn shared_build_opts_ccache(use_ccache: bool) -> Vec<String> {
+pub fn shared_build_opts_ccache(use_ccache: bool, ccache_variant: CcacheVariant) -> Vec<String> {
     if use_ccache {
         vec![
-            "-DCMAKE_C_COMPILER_LAUNCHER='ccache'".to_owned(),
-            "-DCMAKE_CXX_COMPILER_LAUNCHER='ccache'".to_owned(),
+            format!("-DCMAKE_C_COMPILER_LAUNCHER='{}'", ccache_variant),
+            format!("-DCMAKE_CXX_COMPILER_LAUNCHER='{}'", ccache_variant),
         ]
     } else {
         vec![]

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
+use crate::ccache_variant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
 use crate::platforms::Platform;
@@ -26,6 +27,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
@@ -88,6 +90,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             ))
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::SHARED_BUILD_OPTS_NOT_MUSL)

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 use std::process::Command;
 
 use crate::build_type::BuildType;
+use crate::ccache_variant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
 use crate::platforms::Platform;
@@ -27,6 +28,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
@@ -63,6 +65,7 @@ pub fn build(
         llvm_build_crt.as_path(),
         llvm_target_crt.as_path(),
         use_ccache,
+        ccache_variant,
     )?;
     build_host(
         llvm_host_module_llvm.as_path(),
@@ -71,6 +74,7 @@ pub fn build(
         musl_target.as_path(),
         llvm_target_crt.as_path(),
         use_ccache,
+        ccache_variant,
     )?;
     build_target(
         build_type,
@@ -87,6 +91,7 @@ pub fn build(
         enable_coverage,
         extra_args,
         use_ccache,
+        ccache_variant,
         enable_assertions,
         sanitizer,
         enable_valgrind,
@@ -104,6 +109,7 @@ fn build_crt(
     build_directory: &Path,
     target_directory: &Path,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
 ) -> anyhow::Result<()> {
     targets.insert(Platform::X86);
 
@@ -145,6 +151,7 @@ fn build_crt(
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             )),
         "CRT building cmake",
     )?;
@@ -170,6 +177,7 @@ fn build_host(
     musl_target_directory: &Path,
     crt_target_directory: &Path,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
 ) -> anyhow::Result<()> {
     crate::utils::command(
         Command::new("cmake")
@@ -229,6 +237,7 @@ fn build_host(
             .args(crate::platforms::shared::SHARED_BUILD_OPTS)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             )),
         "LLVM host building cmake",
     )?;
@@ -277,6 +286,7 @@ fn build_target(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
@@ -347,6 +357,7 @@ fn build_target(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 use std::process::Command;
 
 use crate::build_type::BuildType;
+use crate::ccache_variant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
 use crate::platforms::Platform;
@@ -26,6 +27,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
 ) -> anyhow::Result<()> {
@@ -86,6 +88,7 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::process::Command;
 
 use crate::build_type::BuildType;
+use crate::ccache_variant;
 use crate::llvm_path::LLVMPath;
 use crate::llvm_project::LLVMProject;
 use crate::platforms::Platform;
@@ -27,6 +28,7 @@ pub fn build(
     enable_coverage: bool,
     extra_args: Vec<String>,
     use_ccache: bool,
+    ccache_variant: ccache_variant::CcacheVariant,
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
 ) -> anyhow::Result<()> {
@@ -95,6 +97,7 @@ pub fn build(
             .args(extra_args)
             .args(crate::platforms::shared::shared_build_opts_ccache(
                 use_ccache,
+                ccache_variant,
             ))
             .args(crate::platforms::shared::shared_build_opts_assertions(
                 enable_assertions,

--- a/src/zksync_llvm/arguments.rs
+++ b/src/zksync_llvm/arguments.rs
@@ -52,6 +52,9 @@ pub enum Arguments {
         /// Whether to use compiler cache (ccache) to speed-up builds.
         #[structopt(long = "use-ccache")]
         use_ccache: bool,
+        /// Compiler cache variant to be used.
+        #[structopt(long = "ccache-variant", default_value = "ccache")]
+        ccache_variant: compiler_llvm_builder::ccache_variant::CcacheVariant,
         /// Whether to build with assertions enabled or not.
         #[structopt(long = "enable-assertions")]
         enable_assertions: bool,

--- a/src/zksync_llvm/main.rs
+++ b/src/zksync_llvm/main.rs
@@ -58,6 +58,7 @@ fn main_inner() -> anyhow::Result<()> {
             enable_coverage,
             extra_args,
             use_ccache,
+            ccache_variant,
             enable_assertions,
             sanitizer,
             enable_valgrind,
@@ -85,7 +86,7 @@ fn main_inner() -> anyhow::Result<()> {
             }
 
             if use_ccache {
-                compiler_llvm_builder::utils::check_presence("ccache")?;
+                compiler_llvm_builder::utils::check_presence(ccache_variant.to_string().as_str())?;
             }
 
             let mut projects = llvm_projects
@@ -106,6 +107,7 @@ fn main_inner() -> anyhow::Result<()> {
                 enable_coverage,
                 extra_args_unescaped,
                 use_ccache,
+                ccache_variant,
                 enable_assertions,
                 sanitizer,
                 enable_valgrind,


### PR DESCRIPTION
# What ❔

Add capability to choose compiler cache variation: `ccache` or `sccache`.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To allow users to use [`sccache`](https://github.com/mozilla/sccache) too as it is more popular and supports Rust too.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
