### PR TITLE
chore: use the Matter Labs bug report URL for LLVM

### DIFF
--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -27,7 +27,7 @@ pub const SHARED_BUILD_OPTS: [&str; 19] = [
     "-DLLVM_ENABLE_LIBEDIT='Off'",
     "-DLLVM_ENABLE_LIBPFM='Off'",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS='On'",
-    "-DPython3_FIND_REGISTRY='LAST'", // Use Python version from PATH, and not from registry,
+    "-DPython3_FIND_REGISTRY='LAST'", // Use Python version from $PATH, not from registry
     "-DBUG_REPORT_URL='https://github.com/matter-labs/era-compiler-llvm/issues/'",
 ];
 

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 use std::process::Command;
 
 /// The build options shared by all platforms.
-pub const SHARED_BUILD_OPTS: [&str; 18] = [
+pub const SHARED_BUILD_OPTS: [&str; 19] = [
     "-DPACKAGE_VENDOR='Matter Labs'",
     "-DCMAKE_BUILD_WITH_INSTALL_RPATH=1",
     "-DLLVM_BUILD_DOCS='Off'",
@@ -27,7 +27,8 @@ pub const SHARED_BUILD_OPTS: [&str; 18] = [
     "-DLLVM_ENABLE_LIBEDIT='Off'",
     "-DLLVM_ENABLE_LIBPFM='Off'",
     "-DCMAKE_EXPORT_COMPILE_COMMANDS='On'",
-    "-DPython3_FIND_REGISTRY='LAST'", // Use Python version from PATH, and not from registry
+    "-DPython3_FIND_REGISTRY='LAST'", // Use Python version from PATH, and not from registry,
+    "-DBUG_REPORT_URL='https://github.com/matter-labs/era-compiler-llvm/issues/'",
 ];
 
 /// The build options shared by all platforms except MUSL.


### PR DESCRIPTION
# What ❔

Use `https://github.com/matter-labs/era-compiler-llvm/issues/` bug report URL instead of default LLVM one.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To suggest users reporting LLVM bugs to us instead of upstream.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
