### PR TITLE
feat: add additional valgrind arguments support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,6 +161,7 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<sanitizer::Sanitizer>,
     enable_valgrind: bool,
+    valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
     std::fs::create_dir_all(LLVMPath::DIRECTORY_LLVM_TARGET)?;
 
@@ -180,6 +181,7 @@ pub fn build(
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
+                    valgrind_options,
                 )?;
             } else if target_env == target_env::TargetEnv::GNU {
                 platforms::x86_64_linux_gnu::build(
@@ -195,6 +197,7 @@ pub fn build(
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
+                    valgrind_options,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for x86_64 and Linux");
@@ -246,6 +249,7 @@ pub fn build(
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
+                    valgrind_options,
                 )?;
             } else if target_env == target_env::TargetEnv::GNU {
                 platforms::aarch64_linux_gnu::build(
@@ -261,6 +265,7 @@ pub fn build(
                     enable_assertions,
                     sanitizer,
                     enable_valgrind,
+                    valgrind_options,
                 )?;
             } else {
                 anyhow::bail!("Unsupported target environment for aarch64 and Linux");

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -30,6 +30,7 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
+    valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -105,6 +106,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::shared_build_opts_valgrind(
                 enable_valgrind,
+                valgrind_options,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -30,6 +30,7 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
+    valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -90,6 +91,7 @@ pub fn build(
         enable_assertions,
         sanitizer,
         enable_valgrind,
+        valgrind_options,
     )?;
 
     Ok(())
@@ -281,6 +283,7 @@ fn build_target(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
+    valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -360,6 +363,7 @@ fn build_target(
             ))
             .args(crate::platforms::shared::shared_build_opts_valgrind(
                 enable_valgrind,
+                valgrind_options,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -177,12 +177,18 @@ pub fn shared_build_opts_sanitizers(sanitizer: Option<Sanitizer>) -> Vec<String>
 ///
 /// The build options to enable Valgrind for LLVM regression tests.
 ///
-pub fn shared_build_opts_valgrind(enabled: bool) -> Vec<String> {
-    if enabled {
-        vec!["-DLLVM_LIT_ARGS='-sv --vg --vg-leak'".to_owned()]
-    } else {
-        vec![]
+pub fn shared_build_opts_valgrind(enabled: bool, valgrind_options: Vec<String>) -> Vec<String> {
+    if !enabled {
+        return vec![];
     }
+
+    let vg_args = valgrind_options
+        .iter()
+        .map(|opt| format!("--vg-arg='{}'", opt))
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    vec![format!("-DLLVM_LIT_ARGS='-sv --vg --vg-leak {}'", vg_args)]
 }
 
 ///

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -30,6 +30,7 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
+    valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -105,6 +106,7 @@ pub fn build(
             ))
             .args(crate::platforms::shared::shared_build_opts_valgrind(
                 enable_valgrind,
+                valgrind_options,
             )),
         "LLVM building cmake",
     )?;

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -31,6 +31,7 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
+    valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
     crate::utils::check_presence("cmake")?;
     crate::utils::check_presence("clang")?;
@@ -91,6 +92,7 @@ pub fn build(
         enable_assertions,
         sanitizer,
         enable_valgrind,
+        valgrind_options,
     )?;
 
     Ok(())
@@ -281,6 +283,7 @@ fn build_target(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
     enable_valgrind: bool,
+    valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
     let mut clang_path = host_target_directory.to_path_buf();
     clang_path.push("bin/clang");
@@ -360,6 +363,7 @@ fn build_target(
             ))
             .args(crate::platforms::shared::shared_build_opts_valgrind(
                 enable_valgrind,
+                valgrind_options,
             )),
         "LLVM target building cmake",
     )?;

--- a/src/zksync_llvm/arguments.rs
+++ b/src/zksync_llvm/arguments.rs
@@ -76,6 +76,10 @@ pub enum Arguments {
         /// Whether to run LLVM unit tests under valgrind or not.
         #[arg(long)]
         enable_valgrind: bool,
+
+        /// Additional valgrind options to pass to the valgrind command.
+        #[arg(long)]
+        valgrind_options: Vec<String>,
     },
 
     /// Checkout the branch specified in `LLVM.lock`.

--- a/src/zksync_llvm/main.rs
+++ b/src/zksync_llvm/main.rs
@@ -55,6 +55,7 @@ fn main_inner() -> anyhow::Result<()> {
             enable_assertions,
             sanitizer,
             enable_valgrind,
+            valgrind_options,
         } => {
             let mut targets = targets
                 .into_iter()
@@ -103,6 +104,7 @@ fn main_inner() -> anyhow::Result<()> {
                 enable_assertions,
                 sanitizer,
                 enable_valgrind,
+                valgrind_options,
             )?;
         }
         Arguments::Checkout { force } => {


### PR DESCRIPTION
# What ❔

Add additional valgrind arguments support.

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

To be able to pass arguments to `valgrind` in lit.

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
