### PR TITLE
fix: --extra-args with multiple args

### DIFF
--- a/src/build_type.rs
+++ b/src/build_type.rs
@@ -26,7 +26,7 @@ impl std::str::FromStr for BuildType {
             "Release" => Ok(Self::Release),
             "RelWithDebInfo" => Ok(Self::RelWithDebInfo),
             "MinSizeRel" => Ok(Self::MinSizeRel),
-            value => Err(format!("Unsupported build type: `{}`", value)),
+            value => Err(format!("Unsupported build type: `{value}`")),
         }
     }
 }

--- a/src/ccache_variant.rs
+++ b/src/ccache_variant.rs
@@ -20,7 +20,7 @@ impl std::str::FromStr for CcacheVariant {
         match value {
             "ccache" => Ok(Self::Ccache),
             "sccache" => Ok(Self::Sccache),
-            value => Err(format!("Unsupported ccache variant: `{}`", value)),
+            value => Err(format!("Unsupported ccache variant: `{value}`")),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,7 @@ use std::process::Command;
 pub fn clone_host() -> anyhow::Result<()> {
     let destination_path = PathBuf::from(LLVMPath::DIRECTORY_LLVM_HOST_SOURCE);
     if destination_path.exists() {
-        eprintln!(
-            "The host repository is already cloned at {:?}. Skipping...",
-            destination_path
-        );
+        eprintln!("The host repository is already cloned at {destination_path:?}. Skipping...",);
         return Ok(());
     }
 
@@ -56,7 +53,7 @@ pub fn clone_host() -> anyhow::Result<()> {
 /// Executes the LLVM repository cloning.
 ///
 pub fn clone(lock: Lock, deep: bool, target_env: target_env::TargetEnv) -> anyhow::Result<()> {
-    utils::check_presence("git")?;
+    utils::exists("git")?;
 
     // Clone the host repository if the target is musl.
     if cfg!(target_os = "linux") && target_env == target_env::TargetEnv::MUSL {
@@ -66,8 +63,7 @@ pub fn clone(lock: Lock, deep: bool, target_env: target_env::TargetEnv) -> anyho
     let destination_path = PathBuf::from(LLVMPath::DIRECTORY_LLVM_SOURCE);
     if destination_path.exists() {
         anyhow::bail!(
-            "The repository is already cloned at {:?}. Use `checkout` instead",
-            destination_path
+            "The repository is already cloned at {destination_path:?}. Use `checkout` instead",
         );
     }
 

--- a/src/llvm_project.rs
+++ b/src/llvm_project.rs
@@ -26,7 +26,7 @@ impl std::str::FromStr for LLVMProject {
             "lld" => Ok(Self::LLD),
             "lldb" => Ok(Self::LLDB),
             "mlir" => Ok(Self::MLIR),
-            value => Err(format!("Unsupported LLVM project to enable: `{}`", value)),
+            value => Err(format!("Unsupported LLVM project to enable: `{value}`")),
         }
     }
 }

--- a/src/lock.rs
+++ b/src/lock.rs
@@ -31,7 +31,7 @@ impl TryFrom<&PathBuf> for Lock {
     fn try_from(path: &PathBuf) -> Result<Self, Self::Error> {
         let mut config_str = String::new();
         let mut config_file =
-            File::open(path).with_context(|| format!("Error opening {:?} file", path))?;
+            File::open(path).with_context(|| format!("Error opening {path:?} file"))?;
         config_file.read_to_string(&mut config_str)?;
         Ok(toml::from_str(&config_str)?)
     }

--- a/src/platforms/aarch64_linux_gnu.rs
+++ b/src/platforms/aarch64_linux_gnu.rs
@@ -32,11 +32,11 @@ pub fn build(
     enable_valgrind: bool,
     valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("cmake")?;
-    crate::utils::check_presence("clang")?;
-    crate::utils::check_presence("clang++")?;
-    crate::utils::check_presence("lld")?;
-    crate::utils::check_presence("ninja")?;
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
 
     let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
     let llvm_build_final = LLVMPath::llvm_build_final()?;

--- a/src/platforms/aarch64_linux_musl.rs
+++ b/src/platforms/aarch64_linux_musl.rs
@@ -32,11 +32,11 @@ pub fn build(
     enable_valgrind: bool,
     valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("cmake")?;
-    crate::utils::check_presence("clang")?;
-    crate::utils::check_presence("clang++")?;
-    crate::utils::check_presence("lld")?;
-    crate::utils::check_presence("ninja")?;
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
 
     let musl_name = "musl-1.2.3";
     let musl_build = LLVMPath::musl_build(musl_name)?;

--- a/src/platforms/aarch64_macos.rs
+++ b/src/platforms/aarch64_macos.rs
@@ -30,8 +30,8 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("cmake")?;
-    crate::utils::check_presence("ninja")?;
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("ninja")?;
 
     let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
     let llvm_build_final = LLVMPath::llvm_build_final()?;

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -35,7 +35,7 @@ impl FromStr for Platform {
         match value {
             "EraVM" => Ok(Self::EraVM),
             "EVM" => Ok(Self::EVM),
-            value => Err(format!("Unsupported platform: `{}`", value)),
+            value => Err(format!("Unsupported platform: `{value}`")),
         }
     }
 }

--- a/src/platforms/shared.rs
+++ b/src/platforms/shared.rs
@@ -188,7 +188,7 @@ pub fn shared_build_opts_rtti(enabled: bool) -> Vec<String> {
 ///
 pub fn shared_build_opts_sanitizers(sanitizer: Option<Sanitizer>) -> Vec<String> {
     match sanitizer {
-        Some(sanitizer) => vec![format!("-DLLVM_USE_SANITIZER='{}'", sanitizer)],
+        Some(sanitizer) => vec![format!("-DLLVM_USE_SANITIZER='{sanitizer}'")],
         None => vec![],
     }
 }
@@ -203,11 +203,11 @@ pub fn shared_build_opts_valgrind(enabled: bool, valgrind_options: Vec<String>) 
 
     let vg_args = valgrind_options
         .iter()
-        .map(|opt| format!("--vg-arg='{}'", opt))
+        .map(|opt| format!("--vg-arg='{opt}'"))
         .collect::<Vec<_>>()
         .join(" ");
 
-    vec![format!("-DLLVM_LIT_ARGS='-sv --vg --vg-leak {}'", vg_args)]
+    vec![format!("-DLLVM_LIT_ARGS='-sv --vg --vg-leak {vg_args}'")]
 }
 
 ///

--- a/src/platforms/x86_64_linux_gnu.rs
+++ b/src/platforms/x86_64_linux_gnu.rs
@@ -32,11 +32,11 @@ pub fn build(
     enable_valgrind: bool,
     valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("cmake")?;
-    crate::utils::check_presence("clang")?;
-    crate::utils::check_presence("clang++")?;
-    crate::utils::check_presence("lld")?;
-    crate::utils::check_presence("ninja")?;
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
 
     let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
     let llvm_build_final = LLVMPath::llvm_build_final()?;

--- a/src/platforms/x86_64_linux_musl.rs
+++ b/src/platforms/x86_64_linux_musl.rs
@@ -33,11 +33,11 @@ pub fn build(
     enable_valgrind: bool,
     valgrind_options: Vec<String>,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("cmake")?;
-    crate::utils::check_presence("clang")?;
-    crate::utils::check_presence("clang++")?;
-    crate::utils::check_presence("lld")?;
-    crate::utils::check_presence("ninja")?;
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
 
     let musl_name = "musl-1.2.3";
     let musl_build = LLVMPath::musl_build(musl_name)?;

--- a/src/platforms/x86_64_macos.rs
+++ b/src/platforms/x86_64_macos.rs
@@ -30,8 +30,8 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("cmake")?;
-    crate::utils::check_presence("ninja")?;
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("ninja")?;
 
     let llvm_module_llvm = LLVMPath::llvm_module_llvm()?;
     let llvm_build_final = LLVMPath::llvm_build_final()?;

--- a/src/platforms/x86_64_windows_gnu.rs
+++ b/src/platforms/x86_64_windows_gnu.rs
@@ -31,11 +31,11 @@ pub fn build(
     enable_assertions: bool,
     sanitizer: Option<Sanitizer>,
 ) -> anyhow::Result<()> {
-    crate::utils::check_presence("cmake")?;
-    crate::utils::check_presence("clang")?;
-    crate::utils::check_presence("clang++")?;
-    crate::utils::check_presence("lld")?;
-    crate::utils::check_presence("ninja")?;
+    crate::utils::exists("cmake")?;
+    crate::utils::exists("clang")?;
+    crate::utils::exists("clang++")?;
+    crate::utils::exists("lld")?;
+    crate::utils::exists("ninja")?;
 
     let llvm_module_llvm =
         LLVMPath::llvm_module_llvm().and_then(crate::utils::path_windows_to_unix)?;
@@ -114,7 +114,7 @@ pub fn build(
     let libstdcpp_source_path = match std::env::var("LIBSTDCPP_SOURCE_PATH") {
         Ok(libstdcpp_source_path) => PathBuf::from(libstdcpp_source_path),
         Err(error) => anyhow::bail!(
-            "The `LIBSTDCPP_SOURCE_PATH` must be set to the path to the libstdc++.a static library: {}", error
+            "The `LIBSTDCPP_SOURCE_PATH` must be set to the path to the libstdc++.a static library: {error}"
         ),
     };
     let mut libstdcpp_destination_path = llvm_target_final;

--- a/src/sanitizer.rs
+++ b/src/sanitizer.rs
@@ -34,7 +34,7 @@ impl std::str::FromStr for Sanitizer {
             "thread" => Ok(Self::Thread),
             "dataflow" => Ok(Self::DataFlow),
             "address;undefined" => Ok(Self::AddressUndefined),
-            value => Err(format!("Unsupported sanitizer: `{}`", value)),
+            value => Err(format!("Unsupported sanitizer: `{value}`")),
         }
     }
 }

--- a/src/target_env.rs
+++ b/src/target_env.rs
@@ -20,7 +20,7 @@ impl std::str::FromStr for TargetEnv {
         match value {
             "gnu" => Ok(Self::GNU),
             "musl" => Ok(Self::MUSL),
-            value => Err(format!("Unsupported target environment: `{}`", value)),
+            value => Err(format!("Unsupported target environment: `{value}`")),
         }
     }
 }

--- a/src/target_triple.rs
+++ b/src/target_triple.rs
@@ -22,7 +22,7 @@ impl std::str::FromStr for TargetTriple {
         match value {
             "eravm" => Ok(Self::EraVM),
             "evm" => Ok(Self::EVM),
-            value => Err(format!("Unsupported target triple: `{}`", value)),
+            value => Err(format!("Unsupported target triple: `{value}`")),
         }
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -42,16 +42,16 @@ pub const MUSL_SNAPSHOTS_URL: &str = "https://git.musl-libc.org/cgit/musl/snapsh
 ///
 pub fn command(command: &mut Command, description: &str) -> anyhow::Result<()> {
     if std::env::var("VERBOSE").is_ok() {
-        println!("\ndescription: {}; command: {:?}", description, command);
+        println!("\ndescription: {description}; command: {command:?}");
     }
     if std::env::var("DRY_RUN").is_ok() {
         println!("\tOnly a dry run; not executing the command.");
     } else {
         let status = command
             .status()
-            .map_err(|error| anyhow::anyhow!("{} process: {}", description, error))?;
+            .map_err(|error| anyhow::anyhow!("{description} process: {error}"))?;
         if !status.success() {
-            anyhow::bail!("{} failed", description);
+            anyhow::bail!("{description} failed");
         }
     }
     Ok(())
@@ -89,7 +89,7 @@ pub fn unpack_tar(filename: PathBuf, path: &str) -> anyhow::Result<()> {
 ///
 pub fn download_musl(name: &str) -> anyhow::Result<()> {
     let tar_file_name = format!("{name}.tar.gz");
-    let url = format!("{}/{tar_file_name}", MUSL_SNAPSHOTS_URL);
+    let url = format!("{MUSL_SNAPSHOTS_URL}/{tar_file_name}");
     download(url.as_str(), crate::LLVMPath::DIRECTORY_LLVM_TARGET)?;
     let musl_tarball = crate::LLVMPath::musl_source(tar_file_name.as_str())?;
     unpack_tar(musl_tarball, crate::LLVMPath::DIRECTORY_LLVM_TARGET)?;
@@ -128,13 +128,13 @@ pub fn path_windows_to_unix<P: AsRef<Path> + PathBufExt>(path: P) -> anyhow::Res
 ///
 /// Checks if the tool exists in the system.
 ///
-pub fn check_presence(name: &str) -> anyhow::Result<()> {
+pub fn exists(name: &str) -> anyhow::Result<()> {
     let status = Command::new("which")
         .arg(name)
         .status()
-        .map_err(|error| anyhow::anyhow!("`which {}` process: {}", name, error))?;
+        .map_err(|error| anyhow::anyhow!("`which {name}` process: {error}"))?;
     if !status.success() {
-        anyhow::bail!("Tool `{}` is missing. Please install", name);
+        anyhow::bail!("Tool `{name}` is missing. Please install");
     }
     Ok(())
 }
@@ -147,14 +147,14 @@ pub fn get_xcode_version() -> anyhow::Result<u32> {
         .args(["--pkg-info", "com.apple.pkg.CLTools_Executables"])
         .stdout(Stdio::piped())
         .spawn()
-        .map_err(|error| anyhow::anyhow!("`pkgutil` process: {}", error))?;
+        .map_err(|error| anyhow::anyhow!("`pkgutil` process: {error}"))?;
     let grep_version = Command::new("grep")
         .arg("version")
         .stdin(Stdio::from(pkgutil.stdout.expect(
             "Failed to identify XCode version - XCode or CLI tools are not installed",
         )))
         .output()
-        .map_err(|error| anyhow::anyhow!("`grep` process: {}", error))?;
+        .map_err(|error| anyhow::anyhow!("`grep` process: {error}"))?;
     let version_string = String::from_utf8(grep_version.stdout)?;
     let version_regex = regex::Regex::new(r"version: (\d+)\..*")?;
     let captures = version_regex

--- a/src/zksync_llvm/arguments.rs
+++ b/src/zksync_llvm/arguments.rs
@@ -58,7 +58,7 @@ pub enum Arguments {
 
         /// Extra arguments to pass to CMake.  
         /// A leading backslash will be unescaped.
-        #[arg(long)]
+        #[arg(long, num_args = 1..)]
         extra_args: Vec<String>,
 
         /// Whether to use compiler cache (ccache) to speed-up builds.

--- a/src/zksync_llvm/main.rs
+++ b/src/zksync_llvm/main.rs
@@ -61,7 +61,7 @@ fn main_inner() -> anyhow::Result<()> {
                 .into_iter()
                 .map(|target| compiler_llvm_builder::Platform::from_str(target.as_str()))
                 .collect::<Result<HashSet<compiler_llvm_builder::Platform>, String>>()
-                .map_err(|platform| anyhow::anyhow!("Unknown platform `{}`", platform))?;
+                .map_err(|platform| anyhow::anyhow!("Unknown platform `{platform}`"))?;
             targets.insert(compiler_llvm_builder::Platform::EraVM);
             targets.insert(compiler_llvm_builder::Platform::EVM);
 
@@ -75,19 +75,19 @@ fn main_inner() -> anyhow::Result<()> {
                 })
                 .collect();
             if env::var("VERBOSE").is_ok() {
-                println!("\nextra_args: {:#?}", extra_args);
-                println!("\nextra_args_unescaped: {:#?}", extra_args_unescaped);
+                println!("\nextra_args: {extra_args:#?}");
+                println!("\nextra_args_unescaped: {extra_args_unescaped:#?}");
             }
 
             if let Some(ccache_variant) = ccache_variant {
-                compiler_llvm_builder::utils::check_presence(ccache_variant.to_string().as_str())?;
+                compiler_llvm_builder::utils::exists(ccache_variant.to_string().as_str())?;
             }
 
             let mut projects = llvm_projects
                 .into_iter()
                 .map(|project| compiler_llvm_builder::llvm_project::LLVMProject::from_str(project.to_string().as_str()))
                 .collect::<Result<HashSet<compiler_llvm_builder::llvm_project::LLVMProject>, String>>()
-                .map_err(|project| anyhow::anyhow!("Unknown LLVM project `{}`", project))?;
+                .map_err(|project| anyhow::anyhow!("Unknown LLVM project `{project}`"))?;
             projects.insert(compiler_llvm_builder::llvm_project::LLVMProject::LLD);
 
             compiler_llvm_builder::build(


### PR DESCRIPTION
# What ❔

Fixes `--extra-args` with multiple args.

## Why ❔

Apparently it was broken by the last `cargo update`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
- [x] Code has been formatted via `cargo fmt` and checked with `cargo clippy`.
